### PR TITLE
Fix crash on new game start in mingw32 builds

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -85,7 +85,12 @@ extern int SCREENHEIGHT;
 #define PACKAGE_VERSION "2.5.0"
 
 /* Set to the attribute to apply to struct definitions to make them packed */
+#ifdef __MINGW32__
+/* Use gcc_struct to work around http://gcc.gnu.org/PR52991 */
+#define PACKEDATTR __attribute__((packed, gcc_struct))
+#else
 #define PACKEDATTR __attribute__((packed))
+#endif
 
 /* Version number of package */
 #define VERSION "2.5.0"


### PR DESCRIPTION
GCC's ms-bitfields option, enabled by default in mingw32, breaks the
behavior of the packed attribute (http://gcc.gnu.org/PR5299). The
workaround is to force GCC's native structure packing rules for packed
structures.