### PR TITLE
Revert "Cleanly error out in retro_load_game"

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -282,9 +282,6 @@ bool retro_load_game(const struct retro_game_info *info)
       { 0 },
    };
 
-   if (!info)
-      return false;
-
    environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
    update_variables(true);


### PR DESCRIPTION
This reverts commit b09203fe512a29c918cf3b7e543c16f8f71f08ed.