### PR TITLE
Don't segfault and abort when loading Heretic

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -137,7 +137,7 @@ static const int nstandard_iwads = sizeof standard_iwads/sizeof*standard_iwads;
  *
  * Called by I/O functions when an event is received.
  * Try event handlers for each code area in turn.
- * cph - in the TRUE spirit of the Boom source, let the 
+ * cph - in the TRUE spirit of the Boom source, let the
  *  short ciruit operator madness begin!
  */
 
@@ -755,7 +755,10 @@ static bool IdentifyVersion (void)
       case retail:
       case registered:
       case shareware:
+        i = strlen(iwad);
         gamemission = doom;
+        if (i>=10 && (!strnicmp(iwad+i-11,"heretic.wad",11) || !strnicmp(iwad+i-13,"hereticsr.wad",13)))
+          return I_Error("IdentifyVersion: Heretic is not supported");
         break;
       case commercial:
         i = strlen(iwad);
@@ -863,14 +866,14 @@ static bool FindResponseFile (void)
                if (size > 0) {
                   char *s = malloc(size+1);
                   char *p = s;
-                  int quoted = 0; 
+                  int quoted = 0;
 
                   while (size > 0) {
                      // Whitespace terminates the token unless quoted
                      if (!quoted && isspace(*infile)) break;
                      if (*infile == '\"') {
                         // Quotes are removed but remembered
-                        infile++; size--; quoted ^= 1; 
+                        infile++; size--; quoted ^= 1;
                      } else {
                         *p++ = *infile++; size--;
                      }
@@ -1272,7 +1275,7 @@ bool D_DoomMainSetup(void)
 
   lprintf(LO_INFO,"\n");     // killough 3/6/98: add a newline, by popular demand :)
 
-  // e6y 
+  // e6y
   // option to disable automatic loading of dehacked-in-wad lump
   if (!M_CheckParm ("-nodeh"))
     // MBF-style DeHackEd in wad support: load all lumps, not just the last one
@@ -1355,7 +1358,7 @@ bool D_DoomMainSetup(void)
       {
         AddDefaultExtension(strcpy(file, myargv[p]), ".deh");
 	fp = fopen(file, "rb");
-	
+
         if (fp == NULL)  // still nope
           I_Error("D_DoomMainSetup: Cannot find .deh or .bex file named %s",
                   myargv[p]);

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -570,6 +570,9 @@ void R_PrecacheLevel(void)
 void R_SetPatchNum(patchnum_t *patchnum, const char *name)
 {
   const rpatch_t *patch = R_CachePatchName(name);
+  if (patch == NULL)
+    return I_Error("R_SetPatchNum: cannot load patch '%s'", name);
+
   patchnum->width = patch->width;
   patchnum->height = patch->height;
   patchnum->leftoffset = patch->leftoffset;

--- a/src/r_patch.c
+++ b/src/r_patch.c
@@ -680,8 +680,15 @@ static void createTextureCompositePatch(int id) {
 const rpatch_t *R_CachePatchNum(int id) {
   const int locks = 1;
 
-  if (!patches)
+  if(id < 0) {
+    I_Error("R_CachePatchNum: missing patch");
+    return NULL;
+  }
+
+  if (!patches) {
     I_Error("R_CachePatchNum: Patches not initialized");
+    return NULL;
+  }
 
   if (!patches[id].data)
     createPatch(id);
@@ -756,4 +763,3 @@ const rcolumn_t *R_GetPatchColumn(const rpatch_t *patch, int columnIndex) {
   if (patch->isNotTileable) return R_GetPatchColumnClamped(patch, columnIndex);
   else return R_GetPatchColumnWrapped(patch, columnIndex);
 }
-

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -369,6 +369,9 @@ static void V_DrawMemPatch(int x, int y, int scrn, const rpatch_t *patch,
 void V_DrawNumPatch(int x, int y, int scrn, int lump,
          int cm, enum patch_translation_e flags)
 {
+  if(lump < 0)
+    return I_Error("V_DrawNumPatch: missing lump won't be drawn");
+    
   V_DrawMemPatch(x, y, scrn, R_CachePatchNum(lump), cm, flags);
   R_UnlockPatchNum(lump);
 }


### PR DESCRIPTION
This adds some checks that avoid segmentation faults when assets from Doom are missing.
Errors will be printed, warning of the missing lumps, instead of crashing retroarch.

This is targeted to handling things like #19 more gracefully.

Hexen aborts gracefully, since the Hexen map format is different, this gets detected in the initialization.
However, in the case of Heretic I added a check in the initialization based on filename, similar to how tnt, plutonia, etc is detected. Otherwise the wad would load but showing only a black screen with many errors about missing images.