### PR TITLE
Add freedoom2.wad & freedoom1.wad to the standard iwads list

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -125,10 +125,12 @@ const char *const standard_iwads[]=
   "doom2.wad",
   "plutonia.wad",
   "tnt.wad",
+  "freedoom2.wad",
   "doom.wad",
-  "doom1.wad",
   "doomu.wad", /* CPhipps - alow doomu.wad */
-  "freedoom.wad", /* wart@kobold.org:  added freedoom for Fedora Extras */
+  "freedoom1.wad",
+  "freedoom.wad",
+  "doom1.wad",
 };
 static const int nstandard_iwads = sizeof standard_iwads/sizeof*standard_iwads;
 


### PR DESCRIPTION
They are the official names the Freedoom project uses now for their iwads.
"freedoom.wad" was a name previously used in some distros.

Also, moved doom1.wad to last position, since it's not really gonna be used from here, it cannot be used in PWADs and when loaded directly from retroarch the list won't be checked.