### PR TITLE
[fix] link with CoreFoundation framework for osx and ios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,14 @@ endif
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
    OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
    fpic += -mmacosx-version-min=10.1
+   LDFLAGS += -framework CoreFoundation
 
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
 	EXT    ?= dylib
    TARGET := $(TARGET_NAME)_libretro_ios.$(EXT)
    fpic := -fPIC
+   LDFLAGS += -framework CoreFoundation
    SHARED := -dynamiclib
 
 ifeq ($(IOSSDK),)


### PR DESCRIPTION
fixes the following linking error

```Undefined symbols for architecture x86_64:
  "_CFBundleCopyBundleURL", referenced from:
      _fill_pathname_application_path in file_path.o
  "_CFBundleGetMainBundle", referenced from:
      _fill_pathname_application_path in file_path.o
  "_CFRelease", referenced from:
      _fill_pathname_application_path in file_path.o
  "_CFStringGetCString", referenced from:
      _fill_pathname_application_path in file_path.o
  "_CFURLCopyPath", referenced from:
      _fill_pathname_application_path in file_path.o
```