### PR TITLE
Gamepad Classic: change JOYPAD_Y mapping from 'toggle run' to 'run'

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -101,7 +101,7 @@ static gamepad_layout_t gp_classic = {
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "Use" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      "Fire" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      "Strafe" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Toggle Run" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Run" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "Strafe Left" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "Strafe Right" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "Previous Weapon" },
@@ -112,7 +112,7 @@ static gamepad_layout_t gp_classic = {
 	},
 	{
 		KEYD_SPACEBAR,   // RETRO_DEVICE_ID_JOYPAD_B      - Use
-		KEYD_CAPSLOCK,   // RETRO DEVICE_ID_JOYPAD_Y      - Toggle Run
+		KEYD_RSHIFT,     // RETRO DEVICE_ID_JOYPAD_Y      - Run
 		KEYD_TAB,        // RETRO_DEVICE_ID_JOYPAD_SELECT - Show/Hide Map
 		KEYD_ESCAPE,     // RETRO_DEVICE_ID_JOYPAD_START  - Show/Hide Menu
 		KEYD_UPARROW,    // RETRO_DEVICE_ID_JOYPAD_UP     - D-Pad Up


### PR DESCRIPTION
This pull request remaps the JOYPAD_Y button of the 'Gamepad Classic' input device from 'toggle run' to 'run' (i.e. hold to run), as per the discussion in issue #47. This better reflects the gamepad controls of the SNES and PSX versions of Doom.

(This should close issue #47)