### PR TITLE
I_FindFile: always use the extension when provided

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1154,7 +1154,7 @@ char* FindFileInDir(const char* dir, const char* wfname, const char* ext)
    FILE * file;
    char * p;
    /* Precalculate a length we will need in the loop */
-   size_t pl = strlen(wfname) + strlen(ext) + 4;
+   size_t pl = strlen(wfname) + (ext && strlen(ext)) + 4;
 
    if( dir == NULL ) {
       p = malloc(pl);
@@ -1165,12 +1165,11 @@ char* FindFileInDir(const char* dir, const char* wfname, const char* ext)
      sprintf(p, "%s%c%s", dir, DIR_SLASH, wfname);
    }
 
-   file = fopen(p, "rb");
-   if (!file)
+   if (ext && ext[0] != '\0')
    {
       strcat(p, ext);
-      file = fopen(p, "rb");
    }
+   file = fopen(p, "rb");
 
    if (file)
    {

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -685,10 +685,10 @@ static char *FindIWADFile(void)
      lprintf(LO_ALWAYS, "myargv[%d]: %s\n", x, myargv[x]);
 
   if (i && (++i < myargc)) {
-    iwad = I_FindFile(myargv[i], ".wad");
+    iwad = I_FindFile(myargv[i], NULL);
   } else {
     for (i=0; !iwad && i<nstandard_iwads; i++)
-      iwad = I_FindFile(standard_iwads[i], ".wad");
+      iwad = I_FindFile(standard_iwads[i], NULL);
   }
   return iwad;
 }
@@ -1068,7 +1068,7 @@ bool D_DoomMainSetup(void)
 
   // Load prboom.wad after IWAD but before everything else
   {
-    char *data_wad_path = I_FindFile(PACKAGE ".wad", ".wad");
+    char *data_wad_path = I_FindFile(PACKAGE ".wad", NULL);
 
     if (!data_wad_path)
     {

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -496,7 +496,7 @@ void S_ChangeMusic(int musicnum, int looping)
     {
       // cournia - check to see if we can play a higher quality music file
       //           rather than the default MIDI
-      music_filename = I_FindFile(S_music_files[musicnum], "");
+      music_filename = I_FindFile(S_music_files[musicnum], NULL);
       if (music_filename)
         {
           music_file_failed = I_RegisterMusic(music_filename, music);


### PR DESCRIPTION
This fixes #48 and fixes #51 

Previous find function was checking first for files without matching the extension and only if no matches were found did it append the extension and try a second time.

This can cause problems when there are files with no extension matching the deh/iwad filename or, in linux, a directory with the same name as the file (which is something the recent changes to the savedir location might lead to, as showcased in #48 and #51).

There's no apparent reason why the old prboom code might have been doing this, probably for commandline convenience so you can call it without specifying the full filename, but this wouldn't apply to libretro, since we require full filename.