### PR TITLE
Adjust game speed in relation to framerate

### DIFF
--- a/src/d_client.c
+++ b/src/d_client.c
@@ -378,7 +378,7 @@ void D_InitNetGame (void)
 
     do
     {
-      do { 
+      do {
 	// Send init packet
 	initpacket.pn = doom_htons(wanted_player_number);
 	packet_set(&initpacket.head, PKT_INIT, 0);
@@ -511,71 +511,56 @@ void D_InitNetGame (void)
   consoleplayer = displayplayer = doomcom->consoleplayer;
 }
 
-#if 0
+
 void D_BuildNewTiccmds(void)
 {
-    static int lastmadetic;
-    int newtics = I_GetTime() - lastmadetic;
-    lastmadetic += newtics;
-    while (newtics--)
-    {
-      I_StartTic();
-      if (maketic - gametic > BACKUPTICS/2) break;
-      G_BuildTiccmd(&localcmds[maketic%BACKUPTICS]);
-      maketic++;
-    }
-}
-#else
-void D_BuildNewTiccmds(void)
-{
-   I_StartTic();
-   G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
-   maketic++;
-}
-#endif
-
-#if 0
-void TryRunTics (void)
-{
-  int runtics;
-
-  // Wait for tics to run
-  while (1) {
-    D_BuildNewTiccmds();
-    runtics = maketic - gametic;
-    if (runtics)
-      break;
-
-        WasRenderedInTryRunTics = TRUE;
-        if (movement_smooth && gamestate==wipegamestate)
-        {
-          isExtraDDisplay = TRUE;
-          D_Display();
-          isExtraDDisplay = FALSE;
-        }
+  static float frac;
+  int fps = 35;
+  switch(movement_smooth)
+  {
+     case 0:
+        fps = 35;
+        break;
+     case 1:
+        fps = 40;
+        break;
+     case 2:
+        fps = 50;
+        break;
+     case 3:
+        fps = 60;
+        break;
+     case 4:
+        fps = 120;
+        break;
+     default:
+        fps = 35;
+        break;
   }
-
-  if (advancedemo)
-	  D_DoAdvanceDemo ();
-  M_Ticker ();
-  I_GetTime_SaveMS();
-  G_Ticker ();
-  P_Checksum(gametic);
-  gametic++;
+  frac += 35;
+  if (frac>0)
+  {
+     frac -= fps;
+     I_StartTic();
+     G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
+     maketic++;
+  }
 }
-#endif
 
 void TryRunTics(void)
 {
-  while (maketic <= gametic)
-     D_BuildNewTiccmds();
-
-  if (advancedemo)
-     D_DoAdvanceDemo ();
-  M_Ticker ();
-  G_Ticker ();
-  P_Checksum(gametic);
-  gametic++;
+  if (maketic <= gametic) {
+    WasRenderedInTryRunTics = TRUE;
+    if (movement_smooth && gamestate==wipegamestate)
+      D_Display();
+  } else {
+    if (advancedemo)
+       D_DoAdvanceDemo ();
+    M_Ticker ();
+    G_Ticker ();
+    P_Checksum(gametic);
+    gametic++;
+  }
 }
 
 #endif

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2019,7 +2019,7 @@ static void M_DrawInstructions(void)
     case S_FILE:
       M_DrawStringCentered(160, 20, CR_SELECT, "Type/edit filename and Press ENTER");
       break;
-    case S_CHOICE: 
+    case S_CHOICE:
       M_DrawStringCentered(160, 20, CR_SELECT, "Press left or right to choose");
       break;
     case S_RESET:
@@ -2195,7 +2195,7 @@ setup_menu_t keys_settings3[] =  // Key Binding screen strings
   {"BEST"    ,S_KEY       ,m_scrn,KB_X,KB_Y+10*8,{&key_weapontoggle}},
   {"FIRE"    ,S_KEY       ,m_scrn,KB_X,KB_Y+11*8,{&key_fire},&mousebfire},
   {"NEXT"    ,S_KEY       ,m_scrn,KB_X,KB_Y+12*8,{&key_weaponcycleup}},
-  {"PREV"    ,S_KEY       ,m_scrn,KB_X,KB_Y+13*8,{&key_weaponcycledown}}, 
+  {"PREV"    ,S_KEY       ,m_scrn,KB_X,KB_Y+13*8,{&key_weaponcycledown}},
 
   {"<- PREV",S_SKIP|S_PREV,m_null,KB_PREV,KB_Y+20*8, {keys_settings2}},
   {"NEXT ->",S_SKIP|S_NEXT,m_null,KB_NEXT,KB_Y+20*8, {keys_settings4}},
@@ -2783,7 +2783,7 @@ enum {
 #define G_YA3 (G_YA2+5*8)
 #define GF_X 76
 
-static const char *framerates[] = {"35fps", "40fps", "50fps", "60fps"};
+static const char *framerates[] = {"35fps", "40fps", "50fps", "60fps", "120fps"};
 static const char *gamma_lvls[] = {"OFF", "Lv. 1", "Lv. 2", "Lv. 3", "Lv. 4"};
 
 setup_menu_t gen_settings1[] = { // General Settings screen1
@@ -2792,7 +2792,7 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 
   {"Framerate", S_CHOICE, m_null, G_X,
   G_YA + general_uncapped*8, {"uncapped_framerate"}, 0, 0, NULL, framerates},
-  
+
   {"Gamma Correction", S_CHOICE, m_null, G_X,
   G_YA + general_gamma*8, {"usegamma"}, 0, 0, NULL, gamma_lvls},
 
@@ -4321,7 +4321,7 @@ boolean M_Responder (event_t* ev) {
     if (ch == key_menu_left) {
       if (ptr1->var.def->type == def_int) {
         int value = *ptr1->var.def->location.pi;
-      
+
         value = value - 1;
         if ((ptr1->var.def->minvalue != UL &&
              value < ptr1->var.def->minvalue))
@@ -4349,7 +4349,7 @@ boolean M_Responder (event_t* ev) {
     if (ch == key_menu_right) {
       if (ptr1->var.def->type == def_int) {
         int value = *ptr1->var.def->location.pi;
-      
+
         value = value + 1;
         if ((ptr1->var.def->minvalue != UL &&
              value < ptr1->var.def->minvalue))
@@ -5061,7 +5061,7 @@ void M_ClearMenus (void)
   menuactive = mnact_inactive;
   print_warning_about_changes = 0;     // killough 8/15/98
   default_verify = 0;                  // killough 10/98
-  
+
   // Have to call this here to ensure that any changes to the
   // gamma correction level are applied immediately...
   V_SetPalette(0);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -265,7 +265,7 @@ default_t defaults[] =
    def_int,ss_none, NULL, NULL},
   {"usegamma",{&usegamma, NULL},{0, NULL},0,4, //jff 3/6/98 fix erroneous upper limit in range
    def_int,ss_none, NULL, NULL}, // gamma correction level // killough 1/18/98
-  {"uncapped_framerate", {&movement_smooth, NULL},  {1, NULL},0,3,
+  {"uncapped_framerate", {&movement_smooth, NULL},  {1, NULL},0,4,
    def_int,ss_stat, NULL, NULL},
   {"filter_wall",{(int*)&drawvars.filterwall, NULL},{RDRAW_FILTER_POINT, NULL},
    RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_none, NULL, NULL},


### PR DESCRIPTION
The game was previously getting  accelerated when the Framerate option
was set to anything higher than 35fps (see #7).

With this change the display will still be refreshed at a higher rate, but the
interpolation code appears to have been scrapped when the engine was ported to libretro so it still needs to be re-added.
Still this is would be the first step to make smooth movement actually work.

Also, I noticed that setting the Framerate option to "60fps" was making it run at 120fps instead. So I've changed it to 60 properly and added a new 120fps option, since the "retro_get_system_av_info" of the core is actually set to run at 120, and some frontends (like Kodi) expect it to
match the core's actual FPS.

Instead of using timers I'm adapting the game tics to the framerate, so that it's still possible to speed up or slow down the game using Retroarch.