### PR TITLE
Smooth movement on higher framerate 

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1368,9 +1368,7 @@ void I_Init(void)
    for (i = 0; i < MAX_PADS; i++)
       doom_devices[i] = RETRO_DEVICE_JOYPAD;
 
-#ifndef __LIBRETRO__
    R_InitInterpolation();
-#endif
 }
 
 /*

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -514,11 +514,11 @@ void D_InitNetGame (void)
 
 void D_BuildNewTiccmds(void)
 {
-  static float frac;
-  frac += 35;
-  if (frac>0)
+  static float tcount;
+  tcount += TICRATE;
+  if (tcount>0)
   {
-     frac -= tic_vars.fps;
+     tcount -= tic_vars.fps;
      I_StartTic();
      G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
      maketic++;
@@ -531,6 +531,8 @@ void TryRunTics(void)
   if(tic_vars.frac > FRACUNIT) {
     tic_vars.frac = FRACUNIT;
   }
+
+  I_StartTic();
 
   if (maketic <= gametic) {
     WasRenderedInTryRunTics = TRUE;

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -515,32 +515,10 @@ void D_InitNetGame (void)
 void D_BuildNewTiccmds(void)
 {
   static float frac;
-  int fps = 35;
-  switch(movement_smooth)
-  {
-     case 0:
-        fps = 35;
-        break;
-     case 1:
-        fps = 40;
-        break;
-     case 2:
-        fps = 50;
-        break;
-     case 3:
-        fps = 60;
-        break;
-     case 4:
-        fps = 120;
-        break;
-     default:
-        fps = 35;
-        break;
-  }
   frac += 35;
   if (frac>0)
   {
-     frac -= fps;
+     frac -= tic_vars.fps;
      I_StartTic();
      G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
      maketic++;
@@ -549,6 +527,11 @@ void D_BuildNewTiccmds(void)
 
 void TryRunTics(void)
 {
+  tic_vars.frac += tic_vars.frac_step;
+  if(tic_vars.frac > FRACUNIT) {
+    tic_vars.frac = FRACUNIT;
+  }
+
   if (maketic <= gametic) {
     WasRenderedInTryRunTics = TRUE;
     if (movement_smooth && gamestate==wipegamestate)
@@ -560,6 +543,7 @@ void TryRunTics(void)
     G_Ticker ();
     P_Checksum(gametic);
     gametic++;
+    tic_vars.frac = 0;
   }
 }
 

--- a/src/d_player.h
+++ b/src/d_player.h
@@ -180,6 +180,10 @@ typedef struct player_s
   int                 resurectedkillcount;
   const char*         centermessage;
 
+  /* used for interpolation */
+  fixed_t prev_viewz;
+  angle_t prev_viewangle;
+
 } player_t;
 
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4211,12 +4211,6 @@ boolean M_Responder (event_t* ev) {
       // Common processing for some items
 
       if (setup_select) { // changing an entry
-  if (ch == key_menu_escape) // Exit key = no change
-    {
-    M_SelectDone(ptr1);                           // phares 4/17/98
-    setup_gather = FALSE;   // finished gathering keys, if any
-    return TRUE;
-    }
 
   if (ptr1->m_flags & S_YESNO) // yes or no setting?
     {
@@ -4374,7 +4368,8 @@ boolean M_Responder (event_t* ev) {
         *ptr1->var.def->location.ppsz = ptr1->selectstrings[value];
       }
     }
-    if (ch == key_menu_enter) {
+    if ((ch == key_menu_enter) ||
+       (ch == key_menu_escape) || (ch == key_fire)) {
       // phares 4/14/98:
       // If not in demoplayback, or netgame,
       // and there's a second variable in var2, set that
@@ -4394,6 +4389,13 @@ boolean M_Responder (event_t* ev) {
     }
     return TRUE;
     }
+
+  if(ch == key_menu_escape) // Exit key = no change
+  {
+    M_SelectDone(ptr1);                           // phares 4/17/98
+    setup_gather = FALSE;   // finished gathering keys, if any
+    return TRUE;
+  }
 
       }
 

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2791,7 +2791,7 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
   {"Video"       ,S_SKIP|S_TITLE, m_null, G_X, G_YA - 12},
 
   {"Framerate", S_CHOICE, m_null, G_X,
-  G_YA + general_uncapped*8, {"uncapped_framerate"}, 0, 0, NULL, framerates},
+  G_YA + general_uncapped*8, {"uncapped_framerate"}, 0, 0, R_InitInterpolation, framerates},
 
   {"Gamma Correction", S_CHOICE, m_null, G_X,
   G_YA + general_gamma*8, {"usegamma"}, 0, 0, NULL, gamma_lvls},

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -56,15 +56,15 @@
 
 boolean onground; // whether player is on ground or in air
 
-/* 
-================== 
-= 
-= P_Thrust 
-= 
-= moves the given origin along a given angle 
-= 
-================== 
-*/ 
+/*
+==================
+=
+= P_Thrust
+=
+= moves the given origin along a given angle
+=
+==================
+*/
 
 void P_Thrust(player_t* player,angle_t angle,fixed_t move)
 {
@@ -110,15 +110,15 @@ static void P_Bob(player_t *player, angle_t angle, fixed_t move)
   player->momy += FixedMul(move,finesine[angle]);
 }
 
-/* 
-================== 
-= 
-= P_CalcHeight 
-= 
+/*
+==================
+=
+= P_CalcHeight
+=
 = Calculate the walking / running height adjustment
 =
-================== 
-*/ 
+==================
+*/
 
 void P_CalcHeight (player_t* player)
 {
@@ -141,7 +141,7 @@ void P_CalcHeight (player_t* player)
    }
 
    //e6y
-   if (compatibility_level >= boom_202_compatibility && 
+   if (compatibility_level >= boom_202_compatibility &&
          compatibility_level <= lxdoom_1_compatibility &&
          player->mo->friction > ORIG_FRICTION) // ice?
    {
@@ -229,7 +229,7 @@ void P_MovePlayer (player_t* player)
      {
         P_Thrust(player, player->mo->angle, FRACUNIT>>8);
      }
-  }	
+  }
   if(cmd->sidemove)
   {
      if(onground || player->mo->flags2&MF2_FLY)
@@ -572,7 +572,7 @@ void P_MorphPlayerThink(player_t *player)
 		{
 			S_StartSound(pmo, SFX_PIG_ACTIVE2);
 		}
-	}		
+	}
 }
 
 //----------------------------------------------------------------------------
@@ -619,7 +619,7 @@ boolean P_UndoPlayerMorph(player_t *player)
          mo = P_SpawnMobj(x, y, z, MT_PLAYER_MAGE);
          break;
       default:
-         I_Error("P_UndoPlayerMorph:  Unknown player class %d\n", 
+         I_Error("P_UndoPlayerMorph:  Unknown player class %d\n",
                player->class);
    }
    if(P_TestMobjLocation(mo) == false)
@@ -637,7 +637,7 @@ boolean P_UndoPlayerMorph(player_t *player)
       return(false);
    }
    if(player->class == PCLASS_FIGHTER)
-   { 
+   {
       // The first type should be blue, and the third should be the
       // Fighter's original gold color
       if(playerNum == 0)
@@ -687,15 +687,13 @@ void P_PlayerThink (player_t* player)
    ticcmd_t*    cmd;
    weapontype_t newweapon;
 
-#ifndef __LIBRETRO__
    if (movement_smooth && &players[displayplayer] == player)
    {
-      original_view_vars.viewx = player->mo->x;
-      original_view_vars.viewy = player->mo->y;
-      original_view_vars.viewz = player->viewz;
-      original_view_vars.viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
+      player->mo->PrevX = player->mo->x;
+      player->mo->PrevY = player->mo->y;
+      player->prev_viewz = player->viewz;
+      player->prev_viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
    }
-#endif
    if (player->mo == 0)
    {
       //printf("player->mo == 0\n");
@@ -720,7 +718,7 @@ void P_PlayerThink (player_t* player)
    }
 
 #ifdef HEXEN
-   // messageTics is above the rest of the counters so that messages will 
+   // messageTics is above the rest of the counters so that messages will
    // 		go away, even in death.
    player->messageTics--; // Can go negative
    if(!player->messageTics || player->messageTics == -1)
@@ -771,32 +769,32 @@ void P_PlayerThink (player_t* player)
    switch(player->class)
    {
       case PCLASS_FIGHTER:
-         if(player->mo->momz <= -35*FRACUNIT 
+         if(player->mo->momz <= -35*FRACUNIT
                && player->mo->momz >= -40*FRACUNIT && !player->morphTics
                && !S_GetSoundPlayingInfo(player->mo,
                   SFX_PLAYER_FIGHTER_FALLING_SCREAM))
          {
-            S_StartSound(player->mo, 
+            S_StartSound(player->mo,
                   SFX_PLAYER_FIGHTER_FALLING_SCREAM);
          }
          break;
       case PCLASS_CLERIC:
-         if(player->mo->momz <= -35*FRACUNIT 
+         if(player->mo->momz <= -35*FRACUNIT
                && player->mo->momz >= -40*FRACUNIT && !player->morphTics
                && !S_GetSoundPlayingInfo(player->mo,
                   SFX_PLAYER_CLERIC_FALLING_SCREAM))
          {
-            S_StartSound(player->mo, 
+            S_StartSound(player->mo,
                   SFX_PLAYER_CLERIC_FALLING_SCREAM);
          }
          break;
       case PCLASS_MAGE:
-         if(player->mo->momz <= -35*FRACUNIT 
+         if(player->mo->momz <= -35*FRACUNIT
                && player->mo->momz >= -40*FRACUNIT && !player->morphTics
                && !S_GetSoundPlayingInfo(player->mo,
                   SFX_PLAYER_MAGE_FALLING_SCREAM))
          {
-            S_StartSound(player->mo, 
+            S_StartSound(player->mo,
                   SFX_PLAYER_MAGE_FALLING_SCREAM);
          }
          break;
@@ -811,12 +809,12 @@ void P_PlayerThink (player_t* player)
          {
             player->mo->momz = 6*FRACUNIT;
          }
-         else 
+         else
          {
             player->mo->momz = 9*FRACUNIT;
          }
          player->mo->flags2 &= ~MF2_ONMOBJ;
-         player->jumpTics = 18; 
+         player->jumpTics = 18;
       }
       else if(cmd->arti&AFLAG_SUICIDE)
       {
@@ -846,7 +844,7 @@ void P_PlayerThink (player_t* player)
 
    /* Check for weapon change. */
 
-   if(cmd->buttons&BT_CHANGE 
+   if(cmd->buttons&BT_CHANGE
 #ifdef HEXEN
          && !player->morphTics
 #endif
@@ -958,7 +956,7 @@ void P_PlayerThink (player_t* player)
                player->mo->flags |= MF_SHADOW;
                player->mo->flags &= ~MF_ALTSHADOW;
             }
-         }		
+         }
       }
       if(!(--player->powers[pw_invulnerability]))
       {
@@ -1020,7 +1018,7 @@ void P_PlayerThink (player_t* player)
       {
          player->poisoncount = 0;
       }
-      P_PoisonDamage(player, player->poisoner, 1, true); 
+      P_PoisonDamage(player, player->poisoner, 1, true);
    }
 #endif
 
@@ -1042,7 +1040,7 @@ void P_PlayerThink (player_t* player)
       {
          if(newtorch)
          {
-            if(player->fixedcolormap+newtorchdelta > 7 
+            if(player->fixedcolormap+newtorchdelta > 7
                   || player->fixedcolormap+newtorchdelta < 1
                   || newtorch == player->fixedcolormap)
                newtorch = 0;

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -53,11 +53,454 @@ typedef enum
 
 boolean WasRenderedInTryRunTics;
 
+typedef struct
+{
+  interpolation_type_e type;
+  void *address;
+} interpolation_t;
+
+static int numinterpolations = 0;
+
+tic_vars_t tic_vars;
+
+static void R_DoAnInterpolation (int i, fixed_t smoothratio);
+void R_ResetViewInterpolation ();
+
+static boolean NoInterpolateView;
+static boolean didInterp;
+
+static interpolation_t *curipos;
+typedef fixed_t fixed2_t[2];
+static fixed2_t *oldipos;
+static fixed2_t *bakipos;
+
+void R_InitInterpolation(void)
+{
+  switch(movement_smooth)
+  {
+    case 0:
+      tic_vars.fps = 35;
+      break;
+    case 1:
+      tic_vars.fps = 40;
+      break;
+    case 2:
+      tic_vars.fps = 50;
+      break;
+    case 3:
+      tic_vars.fps = 60;
+      break;
+    case 4:
+      tic_vars.fps = 120;
+      break;
+    default:
+      tic_vars.fps = TICRATE;
+      break;
+  }
+  tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
+}
+
 void R_InterpolateView (player_t *player)
 {
+
+  static mobj_t *oviewer;
+
+  boolean NoInterpolate = paused || (menuactive && !demoplayback);
+
+  viewplayer = player;
+
+  if (player->mo != oviewer || NoInterpolate)
+  {
+    R_ResetViewInterpolation();
+    oviewer = player->mo;
+  }
+
+  if (NoInterpolate)
+    tic_vars.frac = FRACUNIT;
+
+  if (movement_smooth)
+  {
+    if (NoInterpolateView)
+    {
+      NoInterpolateView = false;
+
+      player->prev_viewz = player->viewz;
+      player->prev_viewangle = player->mo->angle + viewangleoffset;
+      //player->prev_viewpitch = player->mo->pitch + viewpitchoffset;
+
+      //P_ResetWalkcam();
+    }
+
+    viewx = player->mo->PrevX + FixedMul (tic_vars.frac, player->mo->x - player->mo->PrevX);
+    viewy = player->mo->PrevY + FixedMul (tic_vars.frac, player->mo->y - player->mo->PrevY);
+    viewz = player->prev_viewz + FixedMul (tic_vars.frac, player->viewz - player->prev_viewz);
+
+    viewangle = player->prev_viewangle + FixedMul (tic_vars.frac, R_SmoothPlaying_Get(player->mo->angle) - player->prev_viewangle) + viewangleoffset;
+    //viewpitch = player->prev_viewpitch + FixedMul (frac, player->mo->pitch - player->prev_viewpitch) + viewpitchoffset;
+  }
+  else
+  {
     viewx = player->mo->x;
     viewy = player->mo->y;
     viewz = player->viewz;
-    viewangle = R_SmoothPlaying_Get(player->mo->angle);
+
+    viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
+    //viewpitch = player->mo->pitch + viewpitchoffset;
+  }
+
+  if (!paused && movement_smooth)
+  {
+    int i;
+
+    didInterp = tic_vars.frac != FRACUNIT;
+    if (didInterp)
+    {
+      for (i = numinterpolations - 1; i >= 0; i--)
+      {
+        R_DoAnInterpolation (i, tic_vars.frac);
+      }
+    }
+  }
 }
 
+void R_ResetViewInterpolation ()
+{
+  NoInterpolateView = true;
+}
+
+
+static void R_CopyInterpToOld (int i)
+{
+  switch (curipos[i].type)
+  {
+  case INTERP_SectorFloor:
+    oldipos[i][0] = ((sector_t*)curipos[i].address)->floorheight;
+    break;
+  case INTERP_SectorCeiling:
+    oldipos[i][0] = ((sector_t*)curipos[i].address)->ceilingheight;
+    break;
+  case INTERP_Vertex:
+    oldipos[i][0] = ((vertex_t*)curipos[i].address)->x;
+    oldipos[i][1] = ((vertex_t*)curipos[i].address)->y;
+    break;
+  case INTERP_WallPanning:
+    oldipos[i][0] = ((side_t*)curipos[i].address)->rowoffset;
+    oldipos[i][1] = ((side_t*)curipos[i].address)->textureoffset;
+    break;
+  case INTERP_FloorPanning:
+    oldipos[i][0] = ((sector_t*)curipos[i].address)->floor_xoffs;
+    oldipos[i][1] = ((sector_t*)curipos[i].address)->floor_yoffs;
+    break;
+  case INTERP_CeilingPanning:
+    oldipos[i][0] = ((sector_t*)curipos[i].address)->ceiling_xoffs;
+    oldipos[i][1] = ((sector_t*)curipos[i].address)->ceiling_yoffs;
+    break;
+  }
+}
+
+static void R_CopyBakToInterp (int i)
+{
+  switch (curipos[i].type)
+  {
+  case INTERP_SectorFloor:
+    ((sector_t*)curipos[i].address)->floorheight = bakipos[i][0];
+    break;
+  case INTERP_SectorCeiling:
+    ((sector_t*)curipos[i].address)->ceilingheight = bakipos[i][0];
+    break;
+  case INTERP_Vertex:
+    ((vertex_t*)curipos[i].address)->x = bakipos[i][0];
+    ((vertex_t*)curipos[i].address)->y = bakipos[i][1];
+    break;
+  case INTERP_WallPanning:
+    ((side_t*)curipos[i].address)->rowoffset = bakipos[i][0];
+    ((side_t*)curipos[i].address)->textureoffset = bakipos[i][1];
+    break;
+  case INTERP_FloorPanning:
+    ((sector_t*)curipos[i].address)->floor_xoffs = bakipos[i][0];
+    ((sector_t*)curipos[i].address)->floor_yoffs = bakipos[i][1];
+    break;
+  case INTERP_CeilingPanning:
+    ((sector_t*)curipos[i].address)->ceiling_xoffs = bakipos[i][0];
+    ((sector_t*)curipos[i].address)->ceiling_yoffs = bakipos[i][1];
+    break;
+  }
+}
+
+static void R_DoAnInterpolation (int i, fixed_t smoothratio)
+{
+  fixed_t pos;
+  fixed_t *adr1 = NULL;
+  fixed_t *adr2 = NULL;
+
+  switch (curipos[i].type)
+  {
+  case INTERP_SectorFloor:
+    adr1 = &((sector_t*)curipos[i].address)->floorheight;
+    break;
+  case INTERP_SectorCeiling:
+    adr1 = &((sector_t*)curipos[i].address)->ceilingheight;
+    break;
+  case INTERP_Vertex:
+    adr1 = &((vertex_t*)curipos[i].address)->x;
+////    adr2 = &((vertex_t*)curipos[i].Address)->y;
+    break;
+  case INTERP_WallPanning:
+    adr1 = &((side_t*)curipos[i].address)->rowoffset;
+    adr2 = &((side_t*)curipos[i].address)->textureoffset;
+    break;
+  case INTERP_FloorPanning:
+    adr1 = &((sector_t*)curipos[i].address)->floor_xoffs;
+    adr2 = &((sector_t*)curipos[i].address)->floor_yoffs;
+    break;
+  case INTERP_CeilingPanning:
+    adr1 = &((sector_t*)curipos[i].address)->ceiling_xoffs;
+    adr2 = &((sector_t*)curipos[i].address)->ceiling_yoffs;
+    break;
+
+ default:
+    return;
+  }
+
+  if (adr1)
+  {
+    pos = bakipos[i][0] = *adr1;
+    *adr1 = oldipos[i][0] + FixedMul (pos - oldipos[i][0], smoothratio);
+  }
+
+  if (adr2)
+  {
+    pos = bakipos[i][1] = *adr2;
+    *adr2 = oldipos[i][1] + FixedMul (pos - oldipos[i][1], smoothratio);
+  }
+
+}
+
+
+void R_UpdateInterpolations()
+{
+  int i;
+  if (!movement_smooth)
+    return;
+  for (i = numinterpolations-1; i >= 0; --i)
+    R_CopyInterpToOld (i);
+}
+
+int interpolations_max = 0;
+
+static void R_SetInterpolation(interpolation_type_e type, void *posptr)
+{
+  int i;
+  if (!movement_smooth)
+    return;
+
+  if (numinterpolations >= interpolations_max) {
+    interpolations_max = interpolations_max ? interpolations_max * 2 : 256;
+
+    oldipos = (fixed2_t*)realloc(oldipos, sizeof(*oldipos) * interpolations_max);
+    bakipos = (fixed2_t*)realloc(bakipos, sizeof(*bakipos) * interpolations_max);
+    curipos = (interpolation_t*)realloc(curipos, sizeof(*curipos) * interpolations_max);
+  }
+
+  for(i = numinterpolations-1; i >= 0; i--)
+    if (curipos[i].address == posptr && curipos[i].type == type)
+      return;
+
+  curipos[numinterpolations].address = posptr;
+  curipos[numinterpolations].type = type;
+  R_CopyInterpToOld (numinterpolations);
+  numinterpolations++;
+}
+
+static void R_StopInterpolation(interpolation_type_e type, void *posptr)
+{
+  int i;
+
+  if (!movement_smooth)
+    return;
+
+  for(i=numinterpolations-1; i>= 0; --i)
+  {
+    if (curipos[i].address == posptr && curipos[i].type == type)
+    {
+      numinterpolations--;
+      oldipos[i][0] = oldipos[numinterpolations][0];
+      oldipos[i][1] = oldipos[numinterpolations][1];
+      bakipos[i][0] = bakipos[numinterpolations][0];
+      bakipos[i][1] = bakipos[numinterpolations][1];
+      curipos[i] = curipos[numinterpolations];
+      break;
+    }
+  }
+}
+
+void R_StopAllInterpolations(void)
+{
+  int i;
+
+  if (!movement_smooth)
+    return;
+
+  for(i=numinterpolations-1; i>= 0; --i)
+  {
+    numinterpolations--;
+    oldipos[i][0] = oldipos[numinterpolations][0];
+    oldipos[i][1] = oldipos[numinterpolations][1];
+    bakipos[i][0] = bakipos[numinterpolations][0];
+    bakipos[i][1] = bakipos[numinterpolations][1];
+    curipos[i] = curipos[numinterpolations];
+  }
+}
+
+void R_DoInterpolations(fixed_t smoothratio)
+{
+  int i;
+  if (!movement_smooth)
+    return;
+
+  if (smoothratio == FRACUNIT)
+  {
+    didInterp = false;
+    return;
+  }
+
+  didInterp = true;
+
+  for (i = numinterpolations-1; i >= 0; --i)
+  {
+    R_DoAnInterpolation (i, smoothratio);
+  }
+}
+
+void R_RestoreInterpolations()
+{
+  int i;
+
+  if (!movement_smooth)
+    return;
+
+  if (didInterp)
+  {
+    didInterp = false;
+    for (i = numinterpolations-1; i >= 0; --i)
+    {
+      R_CopyBakToInterp (i);
+    }
+  }
+}
+
+void R_ActivateSectorInterpolations()
+{
+  int i;
+  sector_t     *sec;
+
+  if (!movement_smooth)
+    return;
+
+  for (i=0, sec = sectors ; i<numsectors ; i++,sec++)
+  {
+    if (sec->floordata)
+      R_SetInterpolation (INTERP_SectorFloor, sec);
+    if (sec->ceilingdata)
+      R_SetInterpolation (INTERP_SectorCeiling, sec);
+  }
+}
+
+static void R_InterpolationGetData(thinker_t *th,
+  interpolation_type_e *type1, interpolation_type_e *type2,
+  void **posptr1, void **posptr2)
+{
+  *posptr1 = NULL;
+  *posptr2 = NULL;
+
+  if (th->function == T_MoveFloor)
+  {
+    *type1 = INTERP_SectorFloor;
+    *posptr1 = ((floormove_t *)th)->sector;
+  }
+  else
+  if (th->function == T_PlatRaise)
+  {
+    *type1 = INTERP_SectorFloor;
+    *posptr1 = ((plat_t *)th)->sector;
+  }
+  else
+  if (th->function == T_MoveCeiling)
+  {
+    *type1 = INTERP_SectorCeiling;
+    *posptr1 = ((ceiling_t *)th)->sector;
+  }
+  else
+  if (th->function == T_VerticalDoor)
+  {
+    *type1 = INTERP_SectorCeiling;
+    *posptr1 = ((vldoor_t *)th)->sector;
+  }
+  else
+  if (th->function == T_MoveElevator)
+  {
+    *type1 = INTERP_SectorFloor;
+    *posptr1 = ((elevator_t *)th)->sector;
+    *type2 = INTERP_SectorCeiling;
+    *posptr2 = ((elevator_t *)th)->sector;
+  }
+  else
+  if (th->function == T_Scroll)
+  {
+    switch (((scroll_t *)th)->type)
+    {
+      case sc_side:
+        *type1 = INTERP_WallPanning;
+        *posptr1 = sides + ((scroll_t *)th)->affectee;
+        break;
+      case sc_floor:
+        *type1 = INTERP_FloorPanning;
+        *posptr1 = sectors + ((scroll_t *)th)->affectee;
+        break;
+      case sc_ceiling:
+        *type1 = INTERP_CeilingPanning;
+        *posptr1 = sectors + ((scroll_t *)th)->affectee;
+        break;
+      default: ;
+    }
+  }
+}
+
+void R_ActivateThinkerInterpolations(thinker_t *th)
+{
+  void *posptr1;
+  void *posptr2;
+  interpolation_type_e type1, type2;
+
+  if (!movement_smooth)
+    return;
+
+  R_InterpolationGetData(th, &type1, &type2, &posptr1, &posptr2);
+
+  if(posptr1)
+  {
+    R_SetInterpolation (type1, posptr1);
+
+    if(posptr2)
+      R_SetInterpolation (type2, posptr2);
+  }
+}
+
+void R_StopInterpolationIfNeeded(thinker_t *th)
+{
+  void *posptr1;
+  void *posptr2;
+  interpolation_type_e type1, type2;
+
+  if (!movement_smooth)
+    return;
+
+  R_InterpolationGetData(th, &type1, &type2, &posptr1, &posptr2);
+
+  if(posptr1)
+  {
+    R_StopInterpolation (type1, posptr1);
+    if(posptr2)
+      R_StopInterpolation (type2, posptr2);
+  }
+}

--- a/src/r_fps.h
+++ b/src/r_fps.h
@@ -39,8 +39,29 @@
 
 extern int movement_smooth;
 
-extern void R_InterpolateView (player_t *player);
+extern int interpolation_maxobjects;
+
+typedef struct {
+  unsigned int fps;
+  fixed_t frac;
+  fixed_t frac_step;
+} tic_vars_t;
+
+extern tic_vars_t tic_vars;
+
+void R_InitInterpolation(void);
+void R_InterpolateView(player_t *player);
 
 extern boolean WasRenderedInTryRunTics;
+
+void R_ResetViewInterpolation ();
+void R_UpdateInterpolations();
+void R_StopAllInterpolations(void);
+void R_DoInterpolations(fixed_t smoothratio);
+void R_RestoreInterpolations();
+void R_ActivateSectorInterpolations();
+void R_ActivateThinkerInterpolations(thinker_t *th);
+void R_StopInterpolationIfNeeded(thinker_t *th);
+
 
 #endif

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -533,34 +533,15 @@ subsector_t *R_PointInSubsector(fixed_t x, fixed_t y)
 static void R_SetupFrame (player_t *player)
 {
   int cm;
-#ifndef __LIBRETRO__
-  boolean NoInterpolate = paused || (menuactive && !demoplayback);
-#endif
 
-  viewplayer = player;
-
-#ifndef __LIBRETRO__
-  if (player->mo != oviewer || NoInterpolate)
-  {
-    R_ResetViewInterpolation ();
-    oviewer = player->mo;
-  }
-  tic_vars.frac = I_GetTimeFrac ();
-  if (NoInterpolate)
-    tic_vars.frac = FRACUNIT;
-  R_InterpolateView (player, tic_vars.frac);
-#else
   R_InterpolateView (player);
-#endif
 
   extralight = player->extralight;
 
   viewsin = finesine[viewangle>>ANGLETOFINESHIFT];
   viewcos = finecosine[viewangle>>ANGLETOFINESHIFT];
 
-#ifndef __LIBRETRO__
   R_DoInterpolations(tic_vars.frac);
-#endif
 
   // killough 3/20/98, 4/4/98: select colormap based on player status
 

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -468,7 +468,6 @@ static void R_ProjectSprite (mobj_t* thing, int lightlevel)
    fixed_t tz;
    int width;
 
-#ifndef __LIBRETRO__
    if (movement_smooth)
    {
       fx = thing->PrevX + FixedMul (tic_vars.frac, thing->x - thing->PrevX);
@@ -477,13 +476,10 @@ static void R_ProjectSprite (mobj_t* thing, int lightlevel)
    }
    else
    {
-#endif
       fx = thing->x;
       fy = thing->y;
       fz = thing->z;
-#ifndef __LIBRETRO__
    }
-#endif
    tr_x = fx - viewx;
    tr_y = fy - viewy;
 


### PR DESCRIPTION
This is a follow-up on #63
I've adapted the interpolation logic from previous PrBoom and it should now have smoother movement when using higher Framerates. Instead of timers this implementation uses the configured FPS to calculate the fraction of the game tick to which interpolate for.

I also made it so it reads the input on every tic which solves the issue @Tatsuya79 found in the mouse input when using high framerate.

I'd say this fixes #7