### PR TITLE
Framerate: change av_info at runtime and extra framerates

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -26,6 +26,7 @@
 #include "../src/st_stuff.h"
 #include "../src/w_wad.h"
 #include "../src/r_draw.h"
+#include "../src/r_fps.h"
 #include "../src/lprintf.h"
 #include "../src/doomstat.h"
 
@@ -238,13 +239,33 @@ void retro_get_system_info(struct retro_system_info *info)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-   info->timing.fps = 120.0;
-   info->timing.sample_rate = 44100.0;
-   info->geometry.base_width = SCREENWIDTH;
-   info->geometry.base_height = SCREENHEIGHT;
-   info->geometry.max_width = SCREENWIDTH;
-   info->geometry.max_height = SCREENHEIGHT;
-   info->geometry.aspect_ratio = 4.0 / 3.0;
+  switch(movement_smooth)
+  {
+    case 0:
+      info->timing.fps = 35.0;
+      break;
+    case 1:
+      info->timing.fps = 40.0;
+      break;
+    case 2:
+      info->timing.fps = 50.0;
+      break;
+    case 3:
+      info->timing.fps = 60.0;
+      break;
+    case 4:
+      info->timing.fps = 120.0;
+      break;
+    default:
+      info->timing.fps = TICRATE;
+      break;
+  }
+  info->timing.sample_rate = 44100.0;
+  info->geometry.base_width = SCREENWIDTH;
+  info->geometry.base_height = SCREENHEIGHT;
+  info->geometry.max_width = SCREENWIDTH;
+  info->geometry.max_height = SCREENHEIGHT;
+  info->geometry.aspect_ratio = 4.0 / 3.0;
 }
 
 
@@ -260,21 +281,21 @@ void retro_set_environment(retro_environment_t cb)
         { "prboom-menu_back_button", "Menu back button; A|B|X|Y" }, // menu back as core option to be able to map it independently of in-game mappings
 		{ NULL, NULL },
 	};
-	
+
    static const struct retro_controller_description port[] = {
 		{ "Gamepad Modern", RETROPAD_MODERN },
 		{ "Gamepad Classic", RETROPAD_CLASSIC },
 		{ "RetroKeyboard/Mouse", RETRO_DEVICE_KEYBOARD },
 		{ 0 },
    };
-	
+
 	static const struct retro_controller_info ports[] = {
 		{ port, 3 },
 		{ NULL, 0 },
 	};
-	
+
 	environ_cb = cb;
-	
+
 	cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
 	cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
 }
@@ -283,7 +304,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 {
 	if (port)
 		return;
-	
+
 	switch (device)
 	{
 		case RETROPAD_CLASSIC:
@@ -392,7 +413,7 @@ static void update_variables(bool startup)
       else
          find_recursive_on = false;
    }
-   
+
    var.key = "prboom-analog_deadzone";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -601,7 +622,7 @@ bool retro_load_game(const struct retro_game_info *info)
            argv[argc++] = "-deh";
            argv[argc++] = deh;
       };
-      
+
       // Get save directory
       if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &base_save_dir) && base_save_dir)
 		{
@@ -610,7 +631,7 @@ bool retro_load_game(const struct retro_game_info *info)
 				// > Build save path
 				snprintf(g_save_dir, sizeof(g_save_dir), "%s%c%s", base_save_dir, DIR_SLASH, name_without_ext);
 				use_external_savedir = true;
-				
+
 				// > Create save directory, if required
 				if (!path_is_directory(g_save_dir))
 				{
@@ -898,7 +919,7 @@ static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
     bool retro_joypad_b = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
     bool retro_joypad_x = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
     bool retro_joypad_y = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
-	
+
 	for(i = 0; i < num_buttons; i++)
 	{
 		event_t event = {0};
@@ -916,7 +937,7 @@ static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
 			else
 				event.data1 = action_lut[i];
 		}
-		
+
 		if(!new_input[i] && old_input[i])
 		{
 			event.type = ev_keyup;
@@ -929,10 +950,10 @@ static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
 			else
 				event.data1 = action_lut[i];
 		}
-		
+
 		if(event.type == ev_keydown || event.type == ev_keyup)
 			D_PostEvent(&event);
-		
+
 		old_input[i] = new_input[i];
 	}
 }
@@ -944,10 +965,10 @@ static void process_gamepad_left_analog(void)
    bool new_input_analog_l[4];
    int analog_l_amplitude[4];
    static int analog_l_modulation_state[4];
-	
+
 	int lsx = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
 	int lsy = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
-	
+
 	// Get movement 'amplitude' on each axis
 	// > x-axis
 	analog_l_amplitude[0] = 0;
@@ -973,28 +994,28 @@ static void process_gamepad_left_analog(void)
 	{
 		analog_l_amplitude[3] = -1 * (-1 + pwm_period * (lsy + analog_deadzone) / (ANALOG_RANGE - analog_deadzone));
 	}
-	
+
 	for (i = 0; i < 4; i++)
 	{
 		event_t event = {0};
-		
+
 		new_input_analog_l[i] = synthetic_pwm(analog_l_amplitude[i], &analog_l_modulation_state[i]);
-		
+
 		if(new_input_analog_l[i] && !old_input_analog_l[i])
 		{
 			event.type = ev_keydown;
 			event.data1 = left_analog_lut[i];
 		}
-		
+
 		if(!new_input_analog_l[i] && old_input_analog_l[i])
 		{
 			event.type = ev_keyup;
 			event.data1 = left_analog_lut[i];
 		}
-		
+
 		if(event.type == ev_keydown || event.type == ev_keyup)
 			D_PostEvent(&event);
-		
+
 		old_input_analog_l[i] = new_input_analog_l[i];
 	}
 }
@@ -1031,7 +1052,7 @@ static void process_gamepad_right_analog(void)
 		event_mouse.type = ev_mouse;
 		event_mouse.data2 = (ANALOG_MOUSE_SPEED * rsx / (ANALOG_RANGE - analog_deadzone)) * analog_turn_speed;
 	}
-	
+
 	if (rsy < -analog_deadzone || rsy > analog_deadzone)
 	{
 		if (rsy > analog_deadzone)
@@ -1041,7 +1062,7 @@ static void process_gamepad_right_analog(void)
 		event_mouse.type = ev_mouse;
 		event_mouse.data3 = (ANALOG_MOUSE_SPEED * rsy / (ANALOG_RANGE - analog_deadzone)) * analog_turn_speed;
 	}
-	
+
 	if(event_mouse.type == ev_mouse)
 		D_PostEvent(&event_mouse);
 }
@@ -1397,4 +1418,13 @@ void I_Read(int fd, void* vbuf, size_t sz)
       sz  -= rc;
       buf += rc;
    }
+}
+
+void R_InitInterpolation(void)
+{
+  struct retro_system_av_info info;
+  retro_get_system_av_info(&info);
+  environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
+  tic_vars.fps = info.timing.fps;
+  tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
 }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1434,12 +1434,13 @@ void R_InitInterpolation(void)
 {
   struct retro_system_av_info info;
   retro_get_system_av_info(&info);
-  // Only update av_info if changed and it's not the first run
-  if(!tic_vars.fps)
+  if(tic_vars.fps != info.timing.fps) {
+    // Only update av_info if changed and it's not the first run
+    if(tic_vars.fps)
+        environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
+    
     tic_vars.fps = info.timing.fps;
-  else if(tic_vars.fps != info.timing.fps) {
-    environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
-    tic_vars.fps = info.timing.fps;
+    tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
+    tic_vars.sample_step = info.timing.sample_rate / tic_vars.fps;
   }
-  tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
 }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1059,7 +1059,8 @@ static void process_gamepad_right_analog(void)
 		if (rsx < -analog_deadzone)
 			rsx = rsx + analog_deadzone;
 		event_mouse.type = ev_mouse;
-		event_mouse.data2 = (ANALOG_MOUSE_SPEED * rsx / (ANALOG_RANGE - analog_deadzone)) * analog_turn_speed;
+		event_mouse.data2 = ANALOG_MOUSE_SPEED * rsx / (ANALOG_RANGE - analog_deadzone)
+                         * analog_turn_speed * TICRATE / (float)tic_vars.fps;
 	}
 
 	if (rsy < -analog_deadzone || rsy > analog_deadzone)
@@ -1069,7 +1070,8 @@ static void process_gamepad_right_analog(void)
 		if (rsy < -analog_deadzone)
 			rsy = rsy + analog_deadzone;
 		event_mouse.type = ev_mouse;
-		event_mouse.data3 = (ANALOG_MOUSE_SPEED * rsy / (ANALOG_RANGE - analog_deadzone)) * analog_turn_speed;
+		event_mouse.data3 = ANALOG_MOUSE_SPEED * rsy / (ANALOG_RANGE - analog_deadzone)
+                         * analog_turn_speed * TICRATE / (float)tic_vars.fps;
 	}
 
 	if(event_mouse.type == ev_mouse)
@@ -1438,7 +1440,7 @@ void R_InitInterpolation(void)
     // Only update av_info if changed and it's not the first run
     if(tic_vars.fps)
         environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
-    
+
     tic_vars.fps = info.timing.fps;
     tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
     tic_vars.sample_step = info.timing.sample_rate / tic_vars.fps;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1391,6 +1391,7 @@ char* I_FindFile(const char* wfname, const char* ext)
 void I_Init(void)
 {
    int i;
+
    /* killough 2/21/98: avoid sound initialization if no sound & no music */
    if (!(nomusicparm && nosfxparm))
       I_InitSound();
@@ -1433,7 +1434,12 @@ void R_InitInterpolation(void)
 {
   struct retro_system_av_info info;
   retro_get_system_av_info(&info);
-  environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
-  tic_vars.fps = info.timing.fps;
+  // Only update av_info if changed and it's not the first run
+  if(!tic_vars.fps)
+    tic_vars.fps = info.timing.fps;
+  else if(tic_vars.fps != info.timing.fps) {
+    environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &info);
+    tic_vars.fps = info.timing.fps;
+  }
   tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
 }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -254,7 +254,16 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
       info->timing.fps = 60.0;
       break;
     case 4:
+      info->timing.fps = 70.0;
+      break;
+    case 5:
+      info->timing.fps = 100.0;
+      break;
+    case 6:
       info->timing.fps = 120.0;
+      break;
+    case 7:
+      info->timing.fps = 140.0;
       break;
     default:
       info->timing.fps = TICRATE;

--- a/libretro/libretro_sound.c
+++ b/libretro/libretro_sound.c
@@ -378,11 +378,7 @@ void I_UpdateSound(void)
    step = 2;
    frames = 0;
 
-   if(tic_vars.fps) {
-     out_frames = SAMPLERATE / tic_vars.fps;
-   } else {
-     out_frames = SAMPLECOUNT_35;
-   }
+   out_frames = (tic_vars.sample_step)? tic_vars.sample_step : SAMPLECOUNT_35;
 
 #ifdef MUSIC_SUPPORT
    if (music_handle)

--- a/libretro/libretro_sound.c
+++ b/libretro/libretro_sound.c
@@ -24,11 +24,8 @@
 #include "../src/w_wad.h"
 #include "../src/z_zone.h"
 
-#define SAMPLECOUNT_35		((4 * 11025) / 35)
-#define SAMPLECOUNT_40		((4 * 11025) / 40)
-#define SAMPLECOUNT_50		((4 * 11025) / 50)
-#define SAMPLECOUNT_60		((4 * 11025) / 60)
-#define SAMPLECOUNT_120 	((4 * 11025) / 120)
+#define SAMPLERATE    		(4 * 11025)
+#define SAMPLECOUNT_35		(SAMPLERATE / 35)
 #define NUM_CHANNELS		32
 #define BUFMUL           4
 #define MIXBUFFERSIZE   (SAMPLECOUNT_35*BUFMUL)
@@ -381,26 +378,10 @@ void I_UpdateSound(void)
    step = 2;
    frames = 0;
 
-   switch(movement_smooth)
-   {
-      case 0:
-         out_frames = SAMPLECOUNT_35;
-         break;
-      case 1:
-         out_frames = SAMPLECOUNT_40;
-         break;
-      case 2:
-         out_frames = SAMPLECOUNT_50;
-         break;
-      case 3:
-         out_frames = SAMPLECOUNT_60;
-         break;
-      case 4:
-         out_frames = SAMPLECOUNT_120;
-         break;
-      default:
-         out_frames = SAMPLECOUNT_35;
-         break;
+   if(tic_vars.fps) {
+     out_frames = SAMPLERATE / tic_vars.fps;
+   } else {
+     out_frames = SAMPLECOUNT_35;
    }
 
 #ifdef MUSIC_SUPPORT

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2783,7 +2783,8 @@ enum {
 #define G_YA3 (G_YA2+5*8)
 #define GF_X 76
 
-static const char *framerates[] = {"35fps", "40fps", "50fps", "60fps", "120fps"};
+static const char *framerates[] = {"35fps", "40fps", "50fps", "60fps", "70fps",
+  "100fps", "120fps", "140fps"};
 static const char *gamma_lvls[] = {"OFF", "Lv. 1", "Lv. 2", "Lv. 3", "Lv. 4"};
 
 setup_menu_t gen_settings1[] = { // General Settings screen1

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -265,7 +265,7 @@ default_t defaults[] =
    def_int,ss_none, NULL, NULL},
   {"usegamma",{&usegamma, NULL},{0, NULL},0,4, //jff 3/6/98 fix erroneous upper limit in range
    def_int,ss_none, NULL, NULL}, // gamma correction level // killough 1/18/98
-  {"uncapped_framerate", {&movement_smooth, NULL},  {1, NULL},0,4,
+  {"uncapped_framerate", {&movement_smooth, NULL},  {1, NULL},0,7,
    def_int,ss_stat, NULL, NULL},
   {"filter_wall",{(int*)&drawvars.filterwall, NULL},{RDRAW_FILTER_POINT, NULL},
    RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_none, NULL, NULL},

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -74,31 +74,6 @@ typedef fixed_t fixed2_t[2];
 static fixed2_t *oldipos;
 static fixed2_t *bakipos;
 
-void R_InitInterpolation(void)
-{
-  switch(movement_smooth)
-  {
-    case 0:
-      tic_vars.fps = 35;
-      break;
-    case 1:
-      tic_vars.fps = 40;
-      break;
-    case 2:
-      tic_vars.fps = 50;
-      break;
-    case 3:
-      tic_vars.fps = 60;
-      break;
-    case 4:
-      tic_vars.fps = 120;
-      break;
-    default:
-      tic_vars.fps = TICRATE;
-      break;
-  }
-  tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
-}
 
 void R_InterpolateView (player_t *player)
 {

--- a/src/r_fps.h
+++ b/src/r_fps.h
@@ -43,8 +43,9 @@ extern int interpolation_maxobjects;
 
 typedef struct {
   unsigned int fps;
-  fixed_t frac;
-  fixed_t frac_step;
+  fixed_t frac;        /* current fraction of the game tic */
+  fixed_t frac_step;   /* fractional game tic increase per frame */
+  fixed_t sample_step; /* soundsamples per frame */
 } tic_vars_t;
 
 extern tic_vars_t tic_vars;


### PR DESCRIPTION
This is a followup on #64

I'm using RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO as suggested.
I also added 70, 100 and 140fps.
I think 70 and 140 are good idea, since they are multiple of the original 35fps by a factor of 2 and 4, which would round up nicely for the fraction used in the interpolation and should not have any slight bumps in speed (although I don't think that's very perceptible in other framerates to begin with, not even in slow motion).

Sadly I still see screen tearing... I don't know if it's just me, though.

However, this helps Kodi get the right speed when the core is started (although in Kodi, it needs to be restarted to reset the speed after changing the framerate, but this looks like a bug in Kodi, since it works fine in Retroarch).