### PR TITLE
Fix gamepad menu controls

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -89,14 +89,8 @@ static int analog_deadzone = (int)(0.15f * ANALOG_RANGE);
 #define MAX_BUTTON_BINDS 17
 
 // menu enter and back buttons
-boolean menu_enter_a;
-boolean menu_enter_b;
-boolean menu_enter_x;
-boolean menu_enter_y;
-boolean menu_back_a;
-boolean menu_back_b;
-boolean menu_back_x;
-boolean menu_back_y;
+static unsigned menu_enter_button_id;
+static unsigned menu_back_button_id;
 
 typedef struct {
 	struct retro_input_descriptor desc[MAX_BUTTON_BINDS];
@@ -298,8 +292,9 @@ void retro_set_environment(retro_environment_t cb)
 		{ "prboom-mouse_on", "Mouse active when using Gamepad; disabled|enabled" },
 		{ "prboom-find_recursive_on", "Look on parent folders for IWADs; enabled|disabled" },
 		{ "prboom-analog_deadzone", "Analog Deadzone (percent); 15|20|25|30|0|5|10" },
-        { "prboom-menu_enter_button", "Menu enter button; B|X|Y|A" }, // menu enter as core option to be able to map it independently of in-game mappings
-        { "prboom-menu_back_button", "Menu back button; A|B|X|Y" }, // menu back as core option to be able to map it independently of in-game mappings
+      /* Allow menu enter/back to be set independenly of gamepad mapping */
+      { "prboom-menu_enter_action", "Menu enter action; Fire|Use|Run|Next Weapon|Previous Weapon|Toggle Run|180 Turn|Show/Hide Map" },
+      { "prboom-menu_back_action", "Menu back action; Use|Fire|Run|Next Weapon|Previous Weapon|Toggle Run|180 Turn|Show/Hide Map" },
 		{ NULL, NULL },
 	};
 
@@ -319,6 +314,64 @@ void retro_set_environment(retro_environment_t cb)
 
 	cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
 	cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
+}
+
+static void update_menu_controls(void)
+{
+   struct retro_variable var;
+   const struct retro_input_descriptor *desc = NULL;
+   unsigned num_buttons;
+   unsigned i;
+   
+   /* Note: This only works because MAX_PADS is defined to be '1'.
+    * This would have to be changed if multiplayer support is
+    * ever added... */
+   switch (doom_devices[0])
+   {
+      case RETROPAD_CLASSIC:
+         desc = gp_classic.desc;
+         num_buttons = gp_classic.num_buttons;
+         break;
+      case RETROPAD_MODERN:
+         desc = gp_modern.desc;
+         num_buttons = gp_modern.num_buttons;
+         break;
+      case RETRO_DEVICE_KEYBOARD:
+      default:
+         desc = gp_classic.desc;
+         num_buttons = gp_classic.num_buttons;
+         break;
+   }
+   
+   var.key = "prboom-menu_enter_action";
+   var.value = NULL;
+   
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      for (i = 0; i < num_buttons; i++)
+      {
+         if (!strcmp(var.value, desc[i].description))
+         {
+            menu_enter_button_id = desc[i].id;
+            break;
+         }
+      }
+   }
+   
+   var.key = "prboom-menu_back_action";
+   var.value = NULL;
+   
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      for (i = 0; i < num_buttons; i++)
+      {
+         if (!strcmp(var.value, desc[i].description))
+         {
+            menu_back_button_id = desc[i].id;
+            break;
+         }
+      }
+   }
 }
 
 void retro_set_controller_port_device(unsigned port, unsigned device)
@@ -348,6 +401,8 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 			doom_devices[port] = RETROPAD_CLASSIC;
 			environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, gp_classic.desc);
 	}
+   
+   update_menu_controls();
 }
 
 void retro_set_audio_sample(retro_audio_sample_t cb)
@@ -442,74 +497,7 @@ static void update_variables(bool startup)
 		analog_deadzone = (int)(atoi(var.value) * 0.01f * ANALOG_RANGE);
    }
 
-// get menu buttons core option values
-   var.key = "prboom-menu_enter_button";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "A"))
-         {
-         menu_enter_a = true;
-         menu_enter_b = false;
-         menu_enter_x = false;
-         menu_enter_y = false;
-         }
-      else if (!strcmp(var.value, "B"))
-         {
-         menu_enter_a = false;
-         menu_enter_b = true;
-         menu_enter_x = false;
-         menu_enter_y = false;
-         }
-      else if (!strcmp(var.value, "X"))
-         {
-         menu_enter_a = false;
-         menu_enter_b = false;
-         menu_enter_x = true;
-         menu_enter_y = false;
-         }
-      else if (!strcmp(var.value, "Y"))
-         {
-         menu_enter_a = false;
-         menu_enter_b = false;
-         menu_enter_x = false;
-         menu_enter_y = true;
-         }
-    }
-
-   var.key = "prboom-menu_back_button";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "A"))
-         {
-         menu_back_a = true;
-         menu_back_b = false;
-         menu_back_x = false;
-         menu_back_y = false;
-         }
-      else if (!strcmp(var.value, "B"))
-         {
-         menu_back_a = false;
-         menu_back_b = true;
-         menu_back_x = false;
-         menu_back_y = false;
-         }
-      else if (!strcmp(var.value, "X"))
-         {
-         menu_back_a = false;
-         menu_back_b = false;
-         menu_back_x = true;
-         menu_back_y = false;
-         }
-      else if (!strcmp(var.value, "Y"))
-         {
-         menu_back_a = false;
-         menu_back_b = false;
-         menu_back_x = false;
-         menu_back_y = true;
-         }
-   }
+   update_menu_controls();
 }
 
 void I_SafeExit(int rc);
@@ -936,10 +924,6 @@ static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
 	unsigned i;
 	static bool old_input[MAX_BUTTON_BINDS];
 	bool new_input[MAX_BUTTON_BINDS];
-    bool retro_joypad_a = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A); // shortcuts for later
-    bool retro_joypad_b = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
-    bool retro_joypad_x = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
-    bool retro_joypad_y = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
 
 	for(i = 0; i < num_buttons; i++)
 	{
@@ -948,28 +932,52 @@ static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
 
 		if(new_input[i] && !old_input[i])
 		{
-			event.type = ev_keydown;
-			if (menuactive && ((menu_enter_a && retro_joypad_a) || (menu_enter_b && retro_joypad_b) || (menu_enter_x && retro_joypad_x) || (menu_enter_y && retro_joypad_y)))
-				event.data1 = KEYD_ENTER; // press enter only in menus and according to menu enter button core option
-			else if (menuactive && ((menu_back_a && retro_joypad_a) || (menu_back_b && retro_joypad_b) || (menu_back_x && retro_joypad_x) || (menu_back_y && retro_joypad_y)))
-				event.data1 = KEYD_BACKSPACE; // press backspace only in menus and according to menu back button core option
-			else if (menuactive)
-				event.data1 = menu_lut[i]; // use menu_lut only in menus
-			else
-				event.data1 = action_lut[i];
+         event.type = ev_keydown;
+         
+         if (menuactive)
+         {
+            if (i == menu_enter_button_id)
+            {
+               event.data1 = KEYD_ENTER;
+            }
+            else if (i == menu_back_button_id)
+            {
+               event.data1 = KEYD_BACKSPACE;
+            }
+            else
+            {
+               event.data1 = menu_lut[i];
+            }
+         }
+         else
+         {
+            event.data1 = action_lut[i];
+         }
 		}
 
 		if(!new_input[i] && old_input[i])
 		{
 			event.type = ev_keyup;
-			if (menuactive)
-			{
-				event.data1 = KEYD_ENTER; //depress menu keys
-				event.data1 = KEYD_BACKSPACE;
-				event.data1 = menu_lut[i];
-			}
-			else
-				event.data1 = action_lut[i];
+         
+         if (menuactive)
+         {
+            if (i == menu_enter_button_id)
+            {
+               event.data1 = KEYD_ENTER;
+            }
+            else if (i == menu_back_button_id)
+            {
+               event.data1 = KEYD_BACKSPACE;
+            }
+            else
+            {
+               event.data1 = menu_lut[i];
+            }
+         }
+         else
+         {
+            event.data1 = action_lut[i];
+         }
 		}
 
 		if(event.type == ev_keydown || event.type == ev_keyup)


### PR DESCRIPTION
I just updated my copy of this core after a long absence, and discovered that the gamepad menu controls are messed up.

It seems that PR #55 added new core options for setting which buttons act as 'enter' and 'back' on menu screens, but the implementation is flawed: it does not account for gamepad button remapping, so the values set via the core options can in fact 'migrate' to any physical location on the controller (very confusing, and difficult to navigate!)

This PR cleans up the code and changes the 'Menu enter/back' options so they refer to in game *actions* rather than buttons - this allows the setting to stick regardless of how the user remaps their gamepad.