### PR TITLE
[WIP] Adjust tic cmds on higher framerate

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1457,4 +1457,5 @@ void R_InitInterpolation(void)
     tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
     tic_vars.sample_step = info.timing.sample_rate / tic_vars.fps;
   }
+  tic_vars.frac = FRACUNIT;
 }

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -511,42 +511,49 @@ void D_InitNetGame (void)
   consoleplayer = displayplayer = doomcom->consoleplayer;
 }
 
-
 void D_BuildNewTiccmds(void)
 {
-  static float tcount;
-  tcount += TICRATE;
-  if (tcount>0)
+  I_StartTic();
+
+  if (maketic <= gametic)
   {
-     tcount -= tic_vars.fps;
-     I_StartTic();
-     G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
-     maketic++;
+	 // Create new ticcmds if running behind
+	 G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
+	 maketic++;
+  }
+  else
+  {
+	 // Update latest ticcmd if running ahead
+	 ticcmd_t prevcmd = localcmds[(maketic-1) % BACKUPTICS];
+	 ticcmd_t *cmd = &localcmds[(maketic-1) % BACKUPTICS];
+
+	 G_BuildTiccmd(cmd);
+	 cmd->angleturn += prevcmd.angleturn;
+	 cmd->buttons |= prevcmd.buttons;
   }
 }
 
 void TryRunTics(void)
 {
   tic_vars.frac += tic_vars.frac_step;
-  if(tic_vars.frac > FRACUNIT) {
-    tic_vars.frac = FRACUNIT;
+
+  D_BuildNewTiccmds();
+
+  if (movement_smooth && gamestate==wipegamestate) {
+    WasRenderedInTryRunTics = TRUE;
+    D_Display();
   }
 
-  I_StartTic();
-
-  if (maketic <= gametic) {
-    WasRenderedInTryRunTics = TRUE;
-    if (movement_smooth && gamestate==wipegamestate)
-      D_Display();
-  } else {
+  if(tic_vars.frac >= FRACUNIT) {
+    tic_vars.frac -= FRACUNIT;
     if (advancedemo)
-       D_DoAdvanceDemo ();
+      D_DoAdvanceDemo ();
     M_Ticker ();
     G_Ticker ();
     P_Checksum(gametic);
     gametic++;
-    tic_vars.frac = 0;
   }
+
 }
 
 #endif

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -79,6 +79,7 @@ void R_InterpolateView (player_t *player)
 {
 
   static mobj_t *oviewer;
+  fixed_t frac;
 
   boolean NoInterpolate = paused || (menuactive && !demoplayback);
 
@@ -91,7 +92,9 @@ void R_InterpolateView (player_t *player)
   }
 
   if (NoInterpolate)
-    tic_vars.frac = FRACUNIT;
+    frac = FRACUNIT;
+  else
+    frac = tic_vars.frac;
 
   if (movement_smooth)
   {
@@ -101,17 +104,13 @@ void R_InterpolateView (player_t *player)
 
       player->prev_viewz = player->viewz;
       player->prev_viewangle = player->mo->angle + viewangleoffset;
-      //player->prev_viewpitch = player->mo->pitch + viewpitchoffset;
-
-      //P_ResetWalkcam();
     }
 
-    viewx = player->mo->PrevX + FixedMul (tic_vars.frac, player->mo->x - player->mo->PrevX);
-    viewy = player->mo->PrevY + FixedMul (tic_vars.frac, player->mo->y - player->mo->PrevY);
-    viewz = player->prev_viewz + FixedMul (tic_vars.frac, player->viewz - player->prev_viewz);
+    viewx = player->mo->PrevX + FixedMul (frac, player->mo->x - player->mo->PrevX);
+    viewy = player->mo->PrevY + FixedMul (frac, player->mo->y - player->mo->PrevY);
+    viewz = player->prev_viewz + FixedMul (frac, player->viewz - player->prev_viewz);
 
-    viewangle = player->prev_viewangle + FixedMul (tic_vars.frac, R_SmoothPlaying_Get(player->mo->angle) - player->prev_viewangle) + viewangleoffset;
-    //viewpitch = player->prev_viewpitch + FixedMul (frac, player->mo->pitch - player->prev_viewpitch) + viewpitchoffset;
+    viewangle = player->prev_viewangle + FixedMul (frac, R_SmoothPlaying_Get(player->mo->angle) - player->prev_viewangle) + viewangleoffset;
   }
   else
   {
@@ -120,19 +119,18 @@ void R_InterpolateView (player_t *player)
     viewz = player->viewz;
 
     viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
-    //viewpitch = player->mo->pitch + viewpitchoffset;
   }
 
   if (!paused && movement_smooth)
   {
     int i;
 
-    didInterp = tic_vars.frac != FRACUNIT;
+    didInterp = frac != FRACUNIT;
     if (didInterp)
     {
       for (i = numinterpolations - 1; i >= 0; i--)
       {
-        R_DoAnInterpolation (i, tic_vars.frac);
+        R_DoAnInterpolation (i, frac);
       }
     }
   }


### PR DESCRIPTION
EDIT: I  found an issue when using the arrows instead, give me some time to check on this, don't merge yet

This fixes a bug introduced in #64  which prevented the mouse wheel from working due to the input getting lost after being read successively before the game tic could register it.

It also updates TryRunTics so it uses the stored tic fraction and avoids the wipeout animation glitch on the starting title menu previously reported by @Tatsuya79

I believe after this, the remaining known issues after the uncapped framerate was added are:

- Sectors, walls and scrolling textures are still moving at 35 FPS. The code for this was already ported over, but it's at the moment disabled by `#ifndef __LIBRETRO__` in various sections. It doesn't work well when enabled, I still haven't figured out what's wrong. At least this is not a regression and the movement of the player and things should be smooth.

- The wiping "melting" animation for screen transitions is too fast in higher framerates. We could slow this down by proportionally reducing the distance in which the lines go down each tic but this also changes a bit how the meltdown looks, it's not clear to me how other ports are handling this.
