### PR TITLE
Add support for cheats

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -29,6 +29,7 @@
 #include "../src/r_fps.h"
 #include "../src/lprintf.h"
 #include "../src/doomstat.h"
+#include "../src/m_cheat.h"
 
 void I_MPPlayer_Init(void);
 void I_MPPlayer_Free(void);
@@ -753,9 +754,10 @@ void retro_cheat_reset(void)
 
 void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
-   (void)index;
-   (void)enabled;
-   (void)code;
+   (void)index;(void)enabled;
+   if(code)
+	  for(int i=0; code[i] != '\0'; i++)
+		 M_FindCheats(code[i]);
 }
 
 /* i_video */


### PR DESCRIPTION
Makes `retro_cheat_set` able to receive Doom cheats such as "iddqd", "idkfa" or "idclip" that you could type if you had a keyboard, which might not always be the case.
The cheat code should be in the `cheatX_cheatcode` parameter, eg:

```
cheats = 4

cheat0_desc = "Lite-Amp Goggles"
cheat0_code = "idbeholdl"
cheat0_enable = true

cheat1_desc = "Chainsaw"
cheat1_code = "idchoppers"
cheat1_enable = true

cheat2_desc = "Kill all monsters"
cheat2_code = "tntem"
cheat2_enable = true

cheat3_desc = "All Keys"
cheat3_code = "idk"
cheat3_enable = true
```
(full list of supported codes is [here](https://github.com/libretro/libretro-prboom/blob/master/src/m_cheat.c#L110))

Fixes #62 

However, at the moment the cheatcode is entered every time the cheat is turned from OFF to ON.
This is a bit confusing because the state of the cheats as kept by retroarch does not match the real state of the cheats in the game.

I wouldn't be too worried since after all many of the cheats aren't really toggle-able.
But is there a documentation for `retro_cheat_set` and `retro_cheat_reset`? I couldn't find it, and the usage of this libretro API is not clear.

The "enabled" parameter is not really indicating whether the cheat is actually enabled, I assume it matches the `cheatx_enabled` parameter in the cht file.

I noticed when the cheat is OFF the `retro_cheat_reset` method is called, but with no parameters.
Is there any way I can know which cheatcode did the user intend to turn off?