### PR TITLE
Adjust tic cmds on higher framerate

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1457,4 +1457,5 @@ void R_InitInterpolation(void)
     tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
     tic_vars.sample_step = info.timing.sample_rate / tic_vars.fps;
   }
+  tic_vars.frac = FRACUNIT;
 }

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -511,42 +511,49 @@ void D_InitNetGame (void)
   consoleplayer = displayplayer = doomcom->consoleplayer;
 }
 
-
 void D_BuildNewTiccmds(void)
 {
-  static float tcount;
-  tcount += TICRATE;
-  if (tcount>0)
+  I_StartTic();
+
+  if (maketic <= gametic)
   {
-     tcount -= tic_vars.fps;
-     I_StartTic();
-     G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
-     maketic++;
+	 // Create new ticcmds if running behind
+	 G_BuildTiccmd(&localcmds[maketic % BACKUPTICS]);
+	 maketic++;
+  }
+  else
+  {
+	 // Update latest ticcmd if running ahead
+	 ticcmd_t prevcmd = localcmds[(maketic-1) % BACKUPTICS];
+	 ticcmd_t *cmd = &localcmds[(maketic-1) % BACKUPTICS];
+
+	 G_BuildTiccmd(cmd);
+	 cmd->angleturn += prevcmd.angleturn;
+	 cmd->buttons |= prevcmd.buttons;
   }
 }
 
 void TryRunTics(void)
 {
   tic_vars.frac += tic_vars.frac_step;
-  if(tic_vars.frac > FRACUNIT) {
-    tic_vars.frac = FRACUNIT;
+
+  D_BuildNewTiccmds();
+
+  if (movement_smooth && gamestate==wipegamestate) {
+    WasRenderedInTryRunTics = TRUE;
+    D_Display();
   }
 
-  I_StartTic();
-
-  if (maketic <= gametic) {
-    WasRenderedInTryRunTics = TRUE;
-    if (movement_smooth && gamestate==wipegamestate)
-      D_Display();
-  } else {
+  if(tic_vars.frac >= FRACUNIT) {
+    tic_vars.frac -= FRACUNIT;
     if (advancedemo)
-       D_DoAdvanceDemo ();
+      D_DoAdvanceDemo ();
     M_Ticker ();
     G_Ticker ();
     P_Checksum(gametic);
     gametic++;
-    tic_vars.frac = 0;
   }
+
 }
 
 #endif

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -504,13 +504,13 @@ void G_RestartLevel(void)
 
 #include "z_bmalloc.h"
 
-/* 
-============== 
-= 
-= G_DoLoadLevel 
-= 
-============== 
-*/ 
+/*
+==============
+=
+= G_DoLoadLevel
+=
+==============
+*/
 
 static void G_DoLoadLevel (void)
 {
@@ -916,14 +916,14 @@ void G_Ticker (void)
 // also see P_SpawnPlayer in P_Things
 //
 
-/* 
-==================== 
-= 
-= G_PlayerFinishLevel 
-= 
-= Can when a player completes a level 
-==================== 
-*/ 
+/*
+====================
+=
+= G_PlayerFinishLevel
+=
+= Can when a player completes a level
+====================
+*/
 
 static void G_PlayerFinishLevel(int player)
 {
@@ -965,15 +965,15 @@ void G_ChangedPlayerColour(int pn, int cl)
   }
 }
 
-/* 
-==================== 
-= 
-= G_PlayerReborn 
-= 
-= Called after a player dies 
-= almost everything is cleared and initialized 
-==================== 
-*/ 
+/*
+====================
+=
+= G_PlayerReborn
+=
+= Called after a player dies
+= almost everything is cleared and initialized
+====================
+*/
 
 void G_PlayerReborn (int player)
 {
@@ -1015,15 +1015,15 @@ void G_PlayerReborn (int player)
     p->maxammo[i] = maxammo[i];
 }
 
-/* 
-==================== 
-= 
-= G_CheckSpot  
-= 
-= Returns false if the player cannot be respawned at the given mapthing_t spot  
-= because something is occupying it 
-==================== 
-*/ 
+/*
+====================
+=
+= G_CheckSpot
+=
+= Returns false if the player cannot be respawned at the given mapthing_t spot
+= because something is occupying it
+====================
+*/
 
 static boolean G_CheckSpot(int playernum, mapthing_t *mthing)
 {
@@ -1126,15 +1126,15 @@ static boolean G_CheckSpot(int playernum, mapthing_t *mthing)
 }
 
 
-/* 
-==================== 
-= 
-= G_DeathMatchSpawnPlayer 
-= 
-= Spawns a player at one of the random death match spots 
-= called at level load and each death 
-==================== 
-*/ 
+/*
+====================
+=
+= G_DeathMatchSpawnPlayer
+=
+= Spawns a player at one of the random death match spots
+= called at level load and each death
+====================
+*/
 
 void G_DeathMatchSpawnPlayer (int playernum)
 {
@@ -1160,13 +1160,13 @@ void G_DeathMatchSpawnPlayer (int playernum)
    P_SpawnPlayer (playernum, &playerstarts[playernum]);
 }
 
-/* 
-==================== 
-= 
-= G_DoReborn 
-= 
-==================== 
-*/ 
+/*
+====================
+=
+= G_DoReborn
+=
+====================
+*/
 
 void G_DoReborn (int playernum)
 {
@@ -1228,13 +1228,13 @@ int cpars[32] = {
 
 static boolean secretexit;
 
-/* 
-==================== 
-= 
-= G_ExitLevel 
-= 
-==================== 
-*/ 
+/*
+====================
+=
+= G_ExitLevel
+=
+====================
+*/
 
 void G_ExitLevel (void)
 {
@@ -2076,6 +2076,16 @@ void G_SetFastParms(int fast_pending)
         mobjinfo[MT_TROOPSHOT].speed = 10*FRACUNIT;
       }
   }
+}
+
+// Since input is read on each frame, the speed of
+// turns needs to be scaled. This is called whenever
+// the framerate changes.
+void G_ScaleMovementToFramerate (void)
+{
+  angleturn[0] = (320  * TICRATE) / tic_vars.fps;
+  angleturn[1] = (640 * TICRATE) / tic_vars.fps;
+  angleturn[2] = (160  * TICRATE) / tic_vars.fps;
 }
 
 //

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -61,6 +61,7 @@ void G_Ticker(void);
 void G_ReloadDefaults(void);     // killough 3/1/98: loads game defaults
 void G_SaveGameName(char *, size_t, int, boolean); /* killough 3/22/98: sets savegame filename */
 void G_SetFastParms(int);        // killough 4/10/98: sets -fast parameters
+void G_ScaleMovementToFramerate (void);
 void G_DoNewGame(void);
 void G_DoReborn(int playernum);
 void G_DoPlayDemo(void);

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -291,6 +291,7 @@ void M_DrawMessages(void);
 void M_DrawChatStrings(void);
 void M_Compat(int);       // killough 10/98
 void M_ChangeDemoSmoothTurns(void);
+void M_ChangeFramerate(void);
 void M_General(int);      // killough 10/98
 void M_DrawCompat(void);  // killough 10/98
 void M_DrawGeneral(void); // killough 10/98
@@ -2791,7 +2792,7 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
   {"Video"       ,S_SKIP|S_TITLE, m_null, G_X, G_YA - 12},
 
   {"Framerate", S_CHOICE, m_null, G_X,
-  G_YA + general_uncapped*8, {"uncapped_framerate"}, 0, 0, R_InitInterpolation, framerates},
+  G_YA + general_uncapped*8, {"uncapped_framerate"}, 0, 0, M_ChangeFramerate, framerates},
 
   {"Gamma Correction", S_CHOICE, m_null, G_X,
   G_YA + general_gamma*8, {"usegamma"}, 0, 0, NULL, gamma_lvls},
@@ -2961,6 +2962,12 @@ void M_ChangeDemoSmoothTurns(void)
     gen_settings2[12].m_flags |= (S_SKIP|S_SELECT);
 
   R_SmoothPlaying_Reset(NULL);
+}
+
+void M_ChangeFramerate(void)
+{
+  R_InitInterpolation();
+  G_ScaleMovementToFramerate();
 }
 
 // Setting up for the General screen. Turn on flags, set pointers,
@@ -5361,6 +5368,7 @@ void M_Init(void)
   M_InitExtendedHelp(); // init extended help screens // phares 3/30/98
 
   M_ChangeDemoSmoothTurns();
+  M_ChangeFramerate();
 }
 
 //

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -79,6 +79,7 @@ void R_InterpolateView (player_t *player)
 {
 
   static mobj_t *oviewer;
+  fixed_t frac;
 
   boolean NoInterpolate = paused || (menuactive && !demoplayback);
 
@@ -91,7 +92,9 @@ void R_InterpolateView (player_t *player)
   }
 
   if (NoInterpolate)
-    tic_vars.frac = FRACUNIT;
+    frac = FRACUNIT;
+  else
+    frac = tic_vars.frac;
 
   if (movement_smooth)
   {
@@ -101,17 +104,13 @@ void R_InterpolateView (player_t *player)
 
       player->prev_viewz = player->viewz;
       player->prev_viewangle = player->mo->angle + viewangleoffset;
-      //player->prev_viewpitch = player->mo->pitch + viewpitchoffset;
-
-      //P_ResetWalkcam();
     }
 
-    viewx = player->mo->PrevX + FixedMul (tic_vars.frac, player->mo->x - player->mo->PrevX);
-    viewy = player->mo->PrevY + FixedMul (tic_vars.frac, player->mo->y - player->mo->PrevY);
-    viewz = player->prev_viewz + FixedMul (tic_vars.frac, player->viewz - player->prev_viewz);
+    viewx = player->mo->PrevX + FixedMul (frac, player->mo->x - player->mo->PrevX);
+    viewy = player->mo->PrevY + FixedMul (frac, player->mo->y - player->mo->PrevY);
+    viewz = player->prev_viewz + FixedMul (frac, player->viewz - player->prev_viewz);
 
-    viewangle = player->prev_viewangle + FixedMul (tic_vars.frac, R_SmoothPlaying_Get(player->mo->angle) - player->prev_viewangle) + viewangleoffset;
-    //viewpitch = player->prev_viewpitch + FixedMul (frac, player->mo->pitch - player->prev_viewpitch) + viewpitchoffset;
+    viewangle = player->prev_viewangle + FixedMul (frac, R_SmoothPlaying_Get(player->mo->angle) - player->prev_viewangle) + viewangleoffset;
   }
   else
   {
@@ -120,19 +119,18 @@ void R_InterpolateView (player_t *player)
     viewz = player->viewz;
 
     viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
-    //viewpitch = player->mo->pitch + viewpitchoffset;
   }
 
   if (!paused && movement_smooth)
   {
     int i;
 
-    didInterp = tic_vars.frac != FRACUNIT;
+    didInterp = frac != FRACUNIT;
     if (didInterp)
     {
       for (i = numinterpolations - 1; i >= 0; i--)
       {
-        R_DoAnInterpolation (i, tic_vars.frac);
+        R_DoAnInterpolation (i, frac);
       }
     }
   }


### PR DESCRIPTION
Sorry for #68 the turning speed should be fine now for keyboard, mouse and
gamepad analog.

----

D_BuildNewTiccmds should now update previous tic cmd on high framerate
to give better input response. Input is registered every frame, actions
that aren't movement will need a gametic (1/35th of second) to be processed
but they will be accumulated to run on next gametic.

This fixes a bug that prevented the mouse wheel from working due to
the input being lost when being read too quickly in succession for it
to be registered within a gametic.

Also updated the TryRunTics so it's a bit more accurate and avoid the
initial wipeout animation glitch