### PR TITLE
Keybinding-independent gamepad & input changes

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -30,6 +30,7 @@
 #include "../src/lprintf.h"
 #include "../src/doomstat.h"
 #include "../src/m_cheat.h"
+#include "../src/g_game.h"
 
 void I_MPPlayer_Init(void);
 void I_MPPlayer_Free(void);
@@ -89,23 +90,18 @@ static int analog_deadzone = (int)(0.15f * ANALOG_RANGE);
 // (number of gamepad buttons) + 1
 #define MAX_BUTTON_BINDS 17
 
-// menu enter and back buttons
-boolean menu_enter_a;
-boolean menu_enter_b;
-boolean menu_enter_x;
-boolean menu_enter_y;
-boolean menu_back_a;
-boolean menu_back_b;
-boolean menu_back_x;
-boolean menu_back_y;
+typedef struct {
+	int* gamekey;
+	int* menukey;
+} action_lut_t;
 
 typedef struct {
 	struct retro_input_descriptor desc[MAX_BUTTON_BINDS];
-	int action_lut[MAX_BUTTON_BINDS];
+	action_lut_t action_lut[MAX_BUTTON_BINDS];
 	unsigned num_buttons;
 } gamepad_layout_t;
 
-static gamepad_layout_t gp_classic = {
+static gamepad_layout_t gp_classic = { // Based on PS1 Doom Port!
 	{
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "D-Pad Left" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "D-Pad Up" },
@@ -125,64 +121,64 @@ static gamepad_layout_t gp_classic = {
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Show/Hide Menu" },
 		{ 0 },
 	},
-	{
-		KEYD_RALT,       // RETRO_DEVICE_ID_JOYPAD_B      - Strafe
-		KEYD_RSHIFT,     // RETRO DEVICE_ID_JOYPAD_Y      - Run
-		KEYD_TAB,        // RETRO_DEVICE_ID_JOYPAD_SELECT - Show/Hide Map
-		KEYD_ESCAPE,     // RETRO_DEVICE_ID_JOYPAD_START  - Show/Hide Menu
-		KEYD_UPARROW,    // RETRO_DEVICE_ID_JOYPAD_UP     - D-Pad Up
-		KEYD_DOWNARROW,  // RETRO_DEVICE_ID_JOYPAD_DOWN   - D-Pad Down
-		KEYD_LEFTARROW,  // RETRO_DEVICE_ID_JOYPAD_LEFT   - D-Pad Left
-		KEYD_RIGHTARROW, // RETRO_DEVICE_ID_JOYPAD_RIGHT  - D-Pad Right
-		KEYD_SPACEBAR,   // RETRO_DEVICE_ID_JOYPAD_A      - Use
-		KEYD_RCTRL,      // RETRO_DEVICE_ID_JOYPAD_X      - Fire
-		',',             // RETRO_DEVICE_ID_JOYPAD_L1     - Strafe Left
-		'.',             // RETRO_DEVICE_ID_JOYPAD_R1     - Strafe Right
-		'n',             // RETRO_DEVICE_ID_JOYPAD_L2     - Previous Weapon
-		'm',             // RETRO_DEVICE_ID_JOYPAD_R2     - Next Weapon
-		KEYD_CAPSLOCK,   // RETRO_DEVICE_ID_JOYPAD_L3     - Toggle Run - added in case anyone want to use toggle run instead of press to run with classic layout
-		'/',             // RETRO_DEVICE_ID_JOYPAD_R3     - 180 Turn - added in case anyone want it in classic layout
+	{	// gamekey,             menukey
+		{ &key_strafe,          &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_B
+		{ &key_speed,           &key_menu_backspace }, // RETRO DEVICE_ID_JOYPAD_Y
+		{ &key_map,             &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_SELECT
+		{ &key_menu_escape,     &key_menu_escape },    // RETRO_DEVICE_ID_JOYPAD_START
+		{ &key_up,              &key_menu_up },        // RETRO_DEVICE_ID_JOYPAD_UP
+		{ &key_down,            &key_menu_down },      // RETRO_DEVICE_ID_JOYPAD_DOWN
+		{ &key_left,            &key_menu_left },      // RETRO_DEVICE_ID_JOYPAD_LEFT
+		{ &key_right,           &key_menu_right },     // RETRO_DEVICE_ID_JOYPAD_RIGHT
+		{ &key_use,             &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_A
+		{ &key_fire,            &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_X
+		{ &key_strafeleft,      &key_menu_left },      // RETRO_DEVICE_ID_JOYPAD_L1
+		{ &key_straferight,     &key_menu_right },     // RETRO_DEVICE_ID_JOYPAD_R1
+		{ &key_weaponcycledown, &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_L2
+		{ &key_weaponcycleup,   &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_R2
+		{ &key_autorun,         &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_L3
+		{ &key_reverse,         &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_R3
 	},
 	16,
 };
 
-static gamepad_layout_t gp_modern = {
+static gamepad_layout_t gp_modern = { // Based on Original XBOX Doom 3 Collection
 	{
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT,   "D-Pad Left" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,     "D-Pad Up" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,   "D-Pad Down" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "D-Pad Right" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "Use" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,      "Show Last Message" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,      "Next Weapon" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,      "Previous Weapon" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Show/Hide Map" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "Run" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "Fire" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "Quick Save" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     "Quick Load" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,      "Use" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L,      "Quick Load" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,      "Quick Save" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2,     "Run" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2,     "Fire" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3,     "Toggle Run" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3,     "180 Turn" },
-		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Show Last Message" },
+		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Show/Hide Map" },
 		{ 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Show/Hide Menu" },
 		{ 0 },
 	},
-	{ // changed to match with doom classic on ps3
-		KEYD_SPACEBAR,   // RETRO_DEVICE_ID_JOYPAD_B      - Use
-		KEYD_TAB,        // RETRO DEVICE_ID_JOYPAD_Y      - Show/Hide Map
-		KEYD_ENTER,      // RETRO_DEVICE_ID_JOYPAD_SELECT - Show Last Message
-		KEYD_ESCAPE,     // RETRO_DEVICE_ID_JOYPAD_START  - Show/Hide Menu
-		KEYD_UPARROW,    // RETRO_DEVICE_ID_JOYPAD_UP     - D-Pad Up
-		KEYD_DOWNARROW,  // RETRO_DEVICE_ID_JOYPAD_DOWN   - D-Pad Down
-		KEYD_LEFTARROW,  // RETRO_DEVICE_ID_JOYPAD_LEFT   - D-Pad Left
-		KEYD_RIGHTARROW, // RETRO_DEVICE_ID_JOYPAD_RIGHT  - D-Pad Right
-		'm',             // RETRO_DEVICE_ID_JOYPAD_A      - Next Weapon
-		'n',             // RETRO_DEVICE_ID_JOYPAD_X      - Previous Weapon
-		KEYD_RSHIFT,     // RETRO_DEVICE_ID_JOYPAD_L1     - Run
-		KEYD_RCTRL,      // RETRO_DEVICE_ID_JOYPAD_R1     - Fire
-		KEYD_F6,         // RETRO_DEVICE_ID_JOYPAD_L2     - Quick Save
-		KEYD_F9,         // RETRO_DEVICE_ID_JOYPAD_R2     - Quick Load
-		KEYD_CAPSLOCK,   // RETRO_DEVICE_ID_JOYPAD_L3     - Toggle Run
-		'/',             // RETRO_DEVICE_ID_JOYPAD_R3     - 180 Turn
+	{	// gamekey,             menukey
+		{ &key_enter,           &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_B
+		{ &key_use,             &key_menu_enter },     // RETRO DEVICE_ID_JOYPAD_Y
+		{ &key_map,             &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_SELECT
+		{ &key_menu_escape,     &key_menu_escape },    // RETRO_DEVICE_ID_JOYPAD_START
+		{ &key_up,              &key_menu_up },        // RETRO_DEVICE_ID_JOYPAD_UP
+		{ &key_down,            &key_menu_down },      // RETRO_DEVICE_ID_JOYPAD_DOWN
+		{ &key_left,            &key_menu_left },      // RETRO_DEVICE_ID_JOYPAD_LEFT
+		{ &key_right,           &key_menu_right },     // RETRO_DEVICE_ID_JOYPAD_RIGHT
+		{ &key_weaponcycleup,   &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_A
+		{ &key_weaponcycledown, &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_X
+		{ &key_quickload,       &key_menu_left },      // RETRO_DEVICE_ID_JOYPAD_L1
+		{ &key_quicksave,       &key_menu_right },     // RETRO_DEVICE_ID_JOYPAD_R1
+		{ &key_speed,           &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_L2
+		{ &key_fire,            &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_R2
+		{ &key_autorun,         &key_menu_enter },     // RETRO_DEVICE_ID_JOYPAD_L3
+		{ &key_reverse,         &key_menu_backspace }, // RETRO_DEVICE_ID_JOYPAD_R3
 	},
 	16,
 };
@@ -299,8 +295,6 @@ void retro_set_environment(retro_environment_t cb)
 		{ "prboom-mouse_on", "Mouse active when using Gamepad; disabled|enabled" },
 		{ "prboom-find_recursive_on", "Look on parent folders for IWADs; enabled|disabled" },
 		{ "prboom-analog_deadzone", "Analog Deadzone (percent); 15|20|25|30|0|5|10" },
-        { "prboom-menu_enter_button", "Menu enter button; B|X|Y|A" }, // menu enter as core option to be able to map it independently of in-game mappings
-        { "prboom-menu_back_button", "Menu back button; A|B|X|Y" }, // menu back as core option to be able to map it independently of in-game mappings
 		{ NULL, NULL },
 	};
 
@@ -441,75 +435,6 @@ static void update_variables(bool startup)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
 		analog_deadzone = (int)(atoi(var.value) * 0.01f * ANALOG_RANGE);
-   }
-
-// get menu buttons core option values
-   var.key = "prboom-menu_enter_button";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "A"))
-         {
-         menu_enter_a = true;
-         menu_enter_b = false;
-         menu_enter_x = false;
-         menu_enter_y = false;
-         }
-      else if (!strcmp(var.value, "B"))
-         {
-         menu_enter_a = false;
-         menu_enter_b = true;
-         menu_enter_x = false;
-         menu_enter_y = false;
-         }
-      else if (!strcmp(var.value, "X"))
-         {
-         menu_enter_a = false;
-         menu_enter_b = false;
-         menu_enter_x = true;
-         menu_enter_y = false;
-         }
-      else if (!strcmp(var.value, "Y"))
-         {
-         menu_enter_a = false;
-         menu_enter_b = false;
-         menu_enter_x = false;
-         menu_enter_y = true;
-         }
-    }
-
-   var.key = "prboom-menu_back_button";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "A"))
-         {
-         menu_back_a = true;
-         menu_back_b = false;
-         menu_back_x = false;
-         menu_back_y = false;
-         }
-      else if (!strcmp(var.value, "B"))
-         {
-         menu_back_a = false;
-         menu_back_b = true;
-         menu_back_x = false;
-         menu_back_y = false;
-         }
-      else if (!strcmp(var.value, "X"))
-         {
-         menu_back_a = false;
-         menu_back_b = false;
-         menu_back_x = true;
-         menu_back_y = false;
-         }
-      else if (!strcmp(var.value, "Y"))
-         {
-         menu_back_a = false;
-         menu_back_b = false;
-         menu_back_x = false;
-         menu_back_y = true;
-         }
    }
 }
 
@@ -761,36 +686,19 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
          M_FindCheats(code[i]);
 }
 
-/* i_video */
-
-// ensure that only the essential keys are mapped on the menu to avoid unwanted key presses
-static int menu_lut[] = {
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_B */
-   ' ',               /* RETRO DEVICE_ID_JOYPAD_Y */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_SELECT */
-   KEYD_ESCAPE,       /* RETRO_DEVICE_ID_JOYPAD_START */
-   KEYD_UPARROW,      /* RETRO_DEVICE_ID_JOYPAD_UP */
-   KEYD_DOWNARROW,    /* RETRO_DEVICE_ID_JOYPAD_DOWN */
-   KEYD_LEFTARROW,    /* RETRO_DEVICE_ID_JOYPAD_LEFT */
-   KEYD_RIGHTARROW,   /* RETRO_DEVICE_ID_JOYPAD_RIGHT */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_A */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_X */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_L1 */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_R1 */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_L2 */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_R2 */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_L3 */
-   ' ',               /* RETRO_DEVICE_ID_JOYPAD_R3 */
+static action_lut_t left_analog_lut[] = {
+   { &key_straferight, &key_menu_right }, /* RETRO_DEVICE_INDEX_ANALOG_LEFT +X */
+   { &key_strafeleft,  &key_menu_left },  /* RETRO_DEVICE_INDEX_ANALOG_LEFT -X */
+   { &key_down,        &key_menu_down },  /* RETRO_DEVICE_INDEX_ANALOG_LEFT +Y */
+   { &key_up,          &key_menu_up },    /* RETRO_DEVICE_INDEX_ANALOG_LEFT -Y */
 };
 
-static int left_analog_lut[] = {
-   '.',               /* RETRO_DEVICE_INDEX_ANALOG_LEFT +X */
-   ',',               /* RETRO_DEVICE_INDEX_ANALOG_LEFT -X */
-   KEYD_DOWNARROW,    /* RETRO_DEVICE_INDEX_ANALOG_LEFT +Y */
-   KEYD_UPARROW       /* RETRO_DEVICE_INDEX_ANALOG_LEFT -Y */
+static action_lut_t mw_lut[] = {
+   { &key_weaponcycleup,   &key_menu_up },   /* RETRO_DEVICE_ID_MOUSE_WHEELUP */
+   { &key_weaponcycledown, &key_menu_down }, /* RETRO_DEVICE_ID_MOUSE_WHEELDOWN */
 };
 
-static int action_kb_lut[117][2] = {
+static int keyboard_lut[117][2] = {
    {RETROK_BACKSPACE      ,KEYD_BACKSPACE},
    {RETROK_TAB            ,KEYD_TAB},
    {RETROK_CLEAR          ,},
@@ -914,11 +822,6 @@ static int action_kb_lut[117][2] = {
    {RETROK_LALT           ,KEYD_LALT}
 };
 
-static int mw_lut[] = {
-   'm',               /* RETRO_DEVICE_ID_MOUSE_WHEELUP */
-   'n'                /* RETRO_DEVICE_ID_MOUSE_WHEELDOWN */
-};
-
 // Produces a pulse train with average on-time fraction amplitude/pwm_period.
 // (https://www.embeddedrelated.com/showarticle/107.php)
 // > The period here doesn't actually matter that much...
@@ -934,15 +837,11 @@ static bool synthetic_pwm(int amplitude, int* modulation_state)
 	return true;
 }
 
-static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
+static void process_gamepad_buttons(unsigned num_buttons, action_lut_t action_lut[])
 {
 	unsigned i;
 	static bool old_input[MAX_BUTTON_BINDS];
 	bool new_input[MAX_BUTTON_BINDS];
-    bool retro_joypad_a = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A); // shortcuts for later
-    bool retro_joypad_b = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
-    bool retro_joypad_x = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X);
-    bool retro_joypad_y = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
 
 	for(i = 0; i < num_buttons; i++)
 	{
@@ -952,27 +851,13 @@ static void process_gamepad_buttons(unsigned num_buttons, int action_lut[])
 		if(new_input[i] && !old_input[i])
 		{
 			event.type = ev_keydown;
-			if (menuactive && ((menu_enter_a && retro_joypad_a) || (menu_enter_b && retro_joypad_b) || (menu_enter_x && retro_joypad_x) || (menu_enter_y && retro_joypad_y)))
-				event.data1 = KEYD_ENTER; // press enter only in menus and according to menu enter button core option
-			else if (menuactive && ((menu_back_a && retro_joypad_a) || (menu_back_b && retro_joypad_b) || (menu_back_x && retro_joypad_x) || (menu_back_y && retro_joypad_y)))
-				event.data1 = KEYD_BACKSPACE; // press backspace only in menus and according to menu back button core option
-			else if (menuactive)
-				event.data1 = menu_lut[i]; // use menu_lut only in menus
-			else
-				event.data1 = action_lut[i];
+			event.data1 = *((menuactive)? action_lut[i].menukey : action_lut[i].gamekey);
 		}
 
 		if(!new_input[i] && old_input[i])
 		{
 			event.type = ev_keyup;
-			if (menuactive)
-			{
-				event.data1 = KEYD_ENTER; //depress menu keys
-				event.data1 = KEYD_BACKSPACE;
-				event.data1 = menu_lut[i];
-			}
-			else
-				event.data1 = action_lut[i];
+			event.data1 = *((menuactive)? action_lut[i].menukey : action_lut[i].gamekey);
 		}
 
 		if(event.type == ev_keydown || event.type == ev_keyup)
@@ -986,12 +871,18 @@ static void process_gamepad_left_analog(void)
 {
 	unsigned i;
 	static bool old_input_analog_l[4];
-   bool new_input_analog_l[4];
-   int analog_l_amplitude[4];
-   static int analog_l_modulation_state[4];
+	bool new_input_analog_l[4];
+	int analog_l_amplitude[4];
+	static int analog_l_modulation_state[4];
+	int lsx, lsy, analog_range;
 
-	int lsx = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
-	int lsy = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
+	// Only run once per game tic
+	if(tic_vars.frac < FRACUNIT) return;
+	// Increase range on menu
+	analog_range = (menuactive)? ANALOG_RANGE*8 : ANALOG_RANGE;
+
+	lsx = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
+	lsy = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
 
 	// Get movement 'amplitude' on each axis
 	// > x-axis
@@ -1001,22 +892,22 @@ static void process_gamepad_left_analog(void)
 	{
 		// Add '1' to deal with float->int rounding accuracy loss...
 		// (Similarly, subtract '1' when lsx is negative...)
-		analog_l_amplitude[0] = 1 + pwm_period * (lsx - analog_deadzone) / (ANALOG_RANGE - analog_deadzone);
+		analog_l_amplitude[0] = 1 + pwm_period * (lsx - analog_deadzone) / (analog_range - analog_deadzone);
 	}
 	if (lsx < -analog_deadzone)
 	{
-		analog_l_amplitude[1] = -1 * (-1 + pwm_period * (lsx + analog_deadzone) / (ANALOG_RANGE - analog_deadzone));
+		analog_l_amplitude[1] = -1 * (-1 + pwm_period * (lsx + analog_deadzone) / (analog_range - analog_deadzone));
 	}
 	// > y-axis
 	analog_l_amplitude[2] = 0;
 	analog_l_amplitude[3] = 0;
 	if (lsy > analog_deadzone)
 	{
-		analog_l_amplitude[2] = 1 + pwm_period * (lsy - analog_deadzone) / (ANALOG_RANGE - analog_deadzone);
+		analog_l_amplitude[2] = 1 + pwm_period * (lsy - analog_deadzone) / (analog_range - analog_deadzone);
 	}
 	if (lsy < -analog_deadzone)
 	{
-		analog_l_amplitude[3] = -1 * (-1 + pwm_period * (lsy + analog_deadzone) / (ANALOG_RANGE - analog_deadzone));
+		analog_l_amplitude[3] = -1 * (-1 + pwm_period * (lsy + analog_deadzone) / (analog_range - analog_deadzone));
 	}
 
 	for (i = 0; i < 4; i++)
@@ -1028,13 +919,13 @@ static void process_gamepad_left_analog(void)
 		if(new_input_analog_l[i] && !old_input_analog_l[i])
 		{
 			event.type = ev_keydown;
-			event.data1 = left_analog_lut[i];
+			event.data1 = *((menuactive)? left_analog_lut[i].menukey : left_analog_lut[i].gamekey);
 		}
 
 		if(!new_input_analog_l[i] && old_input_analog_l[i])
 		{
 			event.type = ev_keyup;
-			event.data1 = left_analog_lut[i];
+			event.data1 = *((menuactive)? left_analog_lut[i].menukey : left_analog_lut[i].gamekey);;
 		}
 
 		if(event.type == ev_keydown || event.type == ev_keyup)
@@ -1127,18 +1018,18 @@ void I_StartTic (void)
             for(i = 0; i < 117; i++)
             {
                event_t event = {0};
-               new_input_kb[i] = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, action_kb_lut[i][0]);
+               new_input_kb[i] = input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, keyboard_lut[i][0]);
 
                if(new_input_kb[i] && !old_input_kb[i])
                {
                   event.type = ev_keydown;
-                  event.data1 = action_kb_lut[i][1];
+                  event.data1 = keyboard_lut[i][1];
                }
 
                if(!new_input_kb[i] && old_input_kb[i])
                {
                   event.type = ev_keyup;
-                  event.data1 = action_kb_lut[i][1];
+                  event.data1 = keyboard_lut[i][1];
                }
 
                if(event.type == ev_keydown || event.type == ev_keyup)
@@ -1194,13 +1085,13 @@ void I_StartTic (void)
          if (new_input_mw[i] && !old_input_mw[i])
          {
             event_mw.type = ev_keydown;
-            event_mw.data1 = mw_lut[i];
+            event_mw.data1 = *((menuactive)? mw_lut[i].menukey : mw_lut[i].gamekey);
          }
 
          if (!new_input_mw[i] && old_input_mw[i])
          {
             event_mw.type = ev_keyup;
-            event_mw.data1 = mw_lut[i];
+            event_mw.data1 = *((menuactive)? mw_lut[i].menukey : mw_lut[i].gamekey);
          }
 
          if (event_mw.type == ev_keydown || event_mw.type == ev_keyup)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -80,7 +80,7 @@ boolean find_recursive_on;
 // This is scaled by in-game 'mouse sensitivity' option, so just choose a value
 // that has acceptable performance at the default sensitivity value
 // (i.e. user can easily change mouse speed, so absolute value here is not critical)
-#define ANALOG_MOUSE_SPEED 200
+#define ANALOG_MOUSE_SPEED 128
 // Default deadzone: 15%
 static int analog_deadzone = (int)(0.15f * ANALOG_RANGE);
 

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -535,7 +535,12 @@ void D_BuildNewTiccmds(void)
 
 void TryRunTics(void)
 {
+  fixed_t overflow = 0;
   tic_vars.frac += tic_vars.frac_step;
+  if(tic_vars.frac > FRACUNIT) {
+    overflow = tic_vars.frac - FRACUNIT;
+    tic_vars.frac = FRACUNIT;
+  }
 
   D_BuildNewTiccmds();
 
@@ -544,8 +549,8 @@ void TryRunTics(void)
     D_Display();
   }
 
-  if(tic_vars.frac >= FRACUNIT) {
-    tic_vars.frac -= FRACUNIT;
+  if(tic_vars.frac == FRACUNIT) {
+    tic_vars.frac = overflow;
     if (advancedemo)
       D_DoAdvanceDemo ();
     M_Ticker ();


### PR DESCRIPTION
This is a follow up to the discussion on #67
It'd be great if @jdgleaver  and @Sakitoshi could give their +1 before merge

EDIT: Thanks! ready for merge

---

- The gamepad bindings now will work independently of what the user has
configured in PrBoomm keybinding settings. Finally it'll be possible to
set a WASD configuration for keyboard without messing everything up
whenever you feel like plugging a gamepad in the same setup.

- Removed the setting for changing the Menu based on their positions,
since it was conflicting with Retroarch's remappings. Instead a fixed
set of game and menu actions was associated to each gamepad layout.
There are some redundancies in the menu actions so there's some level
of flexibility if the user wants to remap the buttons.

- The modern gamepad is now modeled after the controller mappings from
the original XBOX Doom 3 Collection version of classic Doom. While it's
unfortunate that the bindings are changed (again) I'm hoping this will be
the last time, it was done with some consensus and the change was needed
to avoid confusing conflicts with the menu actions switching when
switching between classic<->modern
![Manual photo](https://user-images.githubusercontent.com/39132563/52917866-e2b9f400-32ce-11e9-96dc-1fc359358a82.png)
(above is a picture of the Doom 3 manual provided by Sakitoshi)

- The mouse wheel now also scrolls through the options of the menu

- Some changes in the left analog to ease it when on the menu.