### PR TITLE
Fix left analog movement

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -824,10 +824,9 @@ static int keyboard_lut[117][2] = {
 
 // Produces a pulse train with average on-time fraction amplitude/pwm_period.
 // (https://www.embeddedrelated.com/showarticle/107.php)
-// > The period here doesn't actually matter that much...
-//   Just set to '60' to match the nominal 60Hz screen refresh rate
-//   (Still works fine when in-game frame rate is set to 35/40/50)
-static int pwm_period = 60;
+// > Now that we process input once per game tic, the period here must
+//   match the internal tic rate (corresponding to default 35fps)
+static const int pwm_period = TICRATE;
 static bool synthetic_pwm(int amplitude, int* modulation_state)
 {
 	*modulation_state += amplitude;


### PR DESCRIPTION
The recent (fantastic) updates to the core have disentangled game speed from frame rate and changed the way that input is handled. As a result, the simulated analog left stick movement now feels 'off' and has a sensitivity that varies with in-game frame rate (i.e. certain movement 'pulses' are being missed).

This was a very simple fix: since input is now sampled once per game tic, the amplitude of the synthetic PWM generator must match the core's internal tic rate. Now left analog analog movement is smooth (or as smooth as it can be!), and independent of frame rate.