### PR TITLE
Load default config values from scanned cfg files

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1284,14 +1284,27 @@ char* FindFileInDir(const char* dir, const char* wfname, const char* ext)
  */
 char* I_FindFile(const char* wfname, const char* ext)
 {
-   char *p, *dir, *system_dir;
+   char *p, *dir, *system_dir, *prboom_system_dir;
    int i;
+
+   // First, check on WAD directory
    if ((p = FindFileInDir(g_wad_dir, wfname, ext)) == NULL)
    {
+     // Then check on system dir (both under prboom subfolder and directly)
      environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
-     if ((!system_dir || (p = FindFileInDir(system_dir, wfname, ext)) == NULL)
-        && find_recursive_on)
-     { // Find recursively on parent directories
+     if (system_dir)
+     {
+       prboom_system_dir = malloc(strlen(system_dir) + 7);
+       sprintf(prboom_system_dir, "%s%c%s", system_dir, DIR_SLASH, "prboom");
+       p = FindFileInDir(prboom_system_dir, wfname, ext);
+       free(prboom_system_dir);
+       if(p == NULL)
+         p = FindFileInDir(system_dir, wfname, ext);
+     }
+
+     // If not found, check on parent folders recursively (if configured to do so)
+     if ( p == NULL && find_recursive_on)
+     {
        dir = malloc(strlen(g_wad_dir));
        strcpy(dir, g_wad_dir);
        for (i = strlen(dir)-1; i > 1; dir[i--] = '\0')

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -532,7 +532,8 @@ bool retro_load_game(const struct retro_game_info *info)
    if(info->path)
    {
       wadinfo_t header;
-      char *deh, *extension;
+      char *deh, *extension, *baseconfig;
+
       char name_without_ext[4096];
       bool use_external_savedir = false;
       const char *base_save_dir = NULL;
@@ -578,6 +579,13 @@ bool retro_load_game(const struct retro_game_info *info)
           argv[argc++] = "-deh";
           argv[argc++] = deh;
         };
+
+        if((baseconfig = FindFileInDir(g_wad_dir, name_without_ext, ".prboom.cfg"))
+         || (baseconfig = I_FindFile("prboom.cfg", NULL)))
+        {
+          argv[argc++] = "-baseconfig";
+          argv[argc++] = baseconfig;
+        }
       }
 
       // Get save directory

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -70,7 +70,7 @@ void D_DoomMain(void);
 void D_AddFile (const char *file, wad_source_t source);
 
 /* cph - MBF-like wad/deh/bex autoload code */
-#define MAXLOADFILES 2
+#define MAXLOADFILES 8
 extern const char *wad_files[MAXLOADFILES], *deh_files[MAXLOADFILES];
 
 #endif

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -4201,19 +4201,21 @@ boolean M_Responder (event_t* ev) {
     // Catch the response to the 'reset to default?' verification
     // screen
 
-    if (default_verify)
-      {
-  if (toupper(ch) == 'Y') {
-    M_ResetDefaults();
-    default_verify = FALSE;
-    M_SelectDone(ptr1);
-  }
-  else if (toupper(ch) == 'N') {
-    default_verify = FALSE;
-    M_SelectDone(ptr1);
-  }
-  return TRUE;
+    if (default_verify) {
+      if (toupper(ch) == 'Y'
+		  || ch == key_menu_enter) {
+        M_ResetDefaults();
+        default_verify = FALSE;
+        M_SelectDone(ptr1);
       }
+      else if (toupper(ch) == 'N'
+               || ch == key_menu_escape
+               || ch == key_menu_backspace) {
+        default_verify = FALSE;
+        M_SelectDone(ptr1);
+      }
+      return TRUE;
+    }
 
       // Common processing for some items
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -179,6 +179,12 @@ default_t defaults[] =
   /* cph - MBF-like wad/deh/bex autoload code */
   {"wadfile_1",{NULL,&wad_files[0]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
   {"wadfile_2",{NULL,&wad_files[1]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_3",{NULL,&wad_files[2]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_4",{NULL,&wad_files[3]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_5",{NULL,&wad_files[4]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_6",{NULL,&wad_files[5]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_7",{NULL,&wad_files[6]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_8",{NULL,&wad_files[7]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
   {"dehfile_1",{NULL,&deh_files[0]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
   {"dehfile_2",{NULL,&deh_files[1]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -161,30 +161,30 @@ default_t defaults[] =
    {-1, NULL},-1,MAX_COMPATIBILITY_LEVEL-1,
    def_int,ss_none, NULL, NULL}, // compatibility level" - CPhipps
   {"menu_background", {(int*)&menu_background, NULL}, {1, NULL}, 0, 1,
-   def_bool,ss_none, NULL, NULL}, // do Boom fullscreen menus have backgrounds?
+   def_bool,ss_gen, NULL, NULL}, // do Boom fullscreen menus have backgrounds?
   {"max_player_corpse", {&bodyquesize, NULL}, {32, NULL},-1,UL,   // killough 2/8/98
-   def_int,ss_none, NULL, NULL}, // number of dead bodies in view supported (-1 = no limit)
+   def_int,ss_gen, NULL, NULL}, // number of dead bodies in view supported (-1 = no limit)
   {"flashing_hom",{&flashing_hom, NULL},{0, NULL},0,1,
-   def_bool,ss_none, NULL, NULL}, // killough 10/98 - enable flashing HOM indicator
+   def_bool,ss_gen, NULL, NULL}, // killough 10/98 - enable flashing HOM indicator
   {"demo_insurance",{&default_demo_insurance, NULL},{2, NULL},0,2,  // killough 3/31/98
    def_int,ss_none, NULL, NULL}, // 1=take special steps ensuring demo sync, 2=only during recordings
   {"level_precache",{(int*)&precache, NULL},{0, NULL},0,1,
    def_bool,ss_none, NULL, NULL}, // precache level data?
   {"demo_smoothturns", {&demo_smoothturns, NULL},  {0, NULL},0,1,
-   def_bool,ss_stat, NULL, NULL},
+   def_bool,ss_gen, NULL, NULL},
   {"demo_smoothturnsfactor", {&demo_smoothturnsfactor, NULL},  {6, NULL},1,SMOOTH_PLAYING_MAXFACTOR,
-   def_int,ss_stat, NULL, NULL},
+   def_int,ss_gen, NULL, NULL},
 
   {"Files",{NULL},{0},UL,UL,def_none,ss_none, NULL, NULL},
   /* cph - MBF-like wad/deh/bex autoload code */
-  {"wadfile_1",{NULL,&wad_files[0]},{0,""},UL,UL,def_str,ss_none, NULL, NULL},
-  {"wadfile_2",{NULL,&wad_files[1]},{0,""},UL,UL,def_str,ss_none, NULL, NULL},
-  {"dehfile_1",{NULL,&deh_files[0]},{0,""},UL,UL,def_str,ss_none, NULL, NULL},
-  {"dehfile_2",{NULL,&deh_files[1]},{0,""},UL,UL,def_str,ss_none, NULL, NULL},
+  {"wadfile_1",{NULL,&wad_files[0]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"wadfile_2",{NULL,&wad_files[1]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"dehfile_1",{NULL,&deh_files[0]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
+  {"dehfile_2",{NULL,&deh_files[1]},{0,""},UL,UL,def_str,ss_gen, NULL, NULL},
 
   {"Game settings",{NULL},{0},UL,UL,def_none,ss_none, NULL, NULL},
   {"default_skill",{&defaultskill, NULL},{3, NULL},1,5, // jff 3/24/98 allow default skill setting
-   def_int,ss_none, NULL, NULL}, // selects default skill 1=TYTD 2=NTR 3=HMP 4=UV 5=NM
+   def_int,ss_gen, NULL, NULL}, // selects default skill 1=TYTD 2=NTR 3=HMP 4=UV 5=NM
   {"weapon_recoil",{&default_weapon_recoil, NULL},{0, NULL},0,1,
    def_bool,ss_weap, &weapon_recoil, NULL},
   /* killough 10/98 - toggle between SG/SSG and Fist/Chainsaw */
@@ -257,38 +257,38 @@ default_t defaults[] =
   {"music_card",{&mus_card, NULL},{-1, NULL},-1,9,       //  to be set,  -1 = autodetect
    def_int,ss_none, NULL, NULL}, // select music driver (DOS), -1 is autodetect, 0 is none"; in Linux, non-zero enables music
   {"pitched_sounds",{&pitched_sounds, NULL},{0, NULL},0,1, // killough 2/21/98
-   def_bool,ss_none, NULL, NULL}, // enables variable pitch in sound effects (from id's original code)
+   def_bool,ss_gen, NULL, NULL}, // enables variable pitch in sound effects (from id's original code)
   {"samplerate",{&snd_samplerate, NULL},{11025, NULL},11025,48000, def_int,ss_none, NULL, NULL},
   {"sfx_volume",{&snd_SfxVolume, NULL},{8, NULL},0,15, def_int,ss_none, NULL, NULL},
   {"music_volume",{&snd_MusicVolume, NULL},{8, NULL},0,15, def_int,ss_none, NULL, NULL},
   {"mus_pause_opt",{&mus_pause_opt, NULL},{2, NULL},0,2, // CPhipps - music pausing
    def_int, ss_none, NULL, NULL}, // 0 = kill music when paused, 1 = pause music, 2 = let music continue
   {"snd_channels",{&default_numChannels, NULL},{8, NULL},1,32,
-   def_int,ss_none, NULL, NULL}, // number of audio events simultaneously // killough
+   def_int,ss_gen, NULL, NULL}, // number of audio events simultaneously // killough
 
   {"Video settings",{NULL, NULL},{0, NULL},UL,UL,def_none,ss_none, NULL, NULL},
   {"screenblocks",{&screenblocks, NULL},{10, NULL},3,11,  // killough 2/21/98: default to 10
    def_int,ss_none, NULL, NULL},
   {"usegamma",{&usegamma, NULL},{0, NULL},0,4, //jff 3/6/98 fix erroneous upper limit in range
-   def_int,ss_none, NULL, NULL}, // gamma correction level // killough 1/18/98
+   def_int,ss_gen, NULL, NULL}, // gamma correction level // killough 1/18/98
   {"uncapped_framerate", {&movement_smooth, NULL},  {3, NULL},0,11,
-   def_int,ss_stat, NULL, NULL},
+   def_int,ss_gen, NULL, NULL},
   {"filter_wall",{(int*)&drawvars.filterwall, NULL},{RDRAW_FILTER_POINT, NULL},
-   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_none, NULL, NULL},
+   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_gen, NULL, NULL},
   {"filter_floor",{(int*)&drawvars.filterfloor, NULL},{RDRAW_FILTER_POINT, NULL},
-   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_none, NULL, NULL},
+   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_gen, NULL, NULL},
   {"filter_sprite",{(int*)&drawvars.filtersprite, NULL},{RDRAW_FILTER_POINT, NULL},
-   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_none, NULL, NULL},
+   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_gen, NULL, NULL},
   {"filter_z",{(int*)&drawvars.filterz, NULL},{RDRAW_FILTER_POINT, NULL},
-   RDRAW_FILTER_POINT, RDRAW_FILTER_LINEAR, def_int,ss_none, NULL, NULL},
+   RDRAW_FILTER_POINT, RDRAW_FILTER_LINEAR, def_int,ss_gen, NULL, NULL},
   {"filter_patch",{(int*)&drawvars.filterpatch, NULL},{RDRAW_FILTER_POINT, NULL},
-   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_none, NULL, NULL},
+   RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_gen, NULL, NULL},
   {"filter_threshold",{(int*)&drawvars.mag_threshold, NULL},{49152, NULL},
    0, UL, def_int,ss_none, NULL, NULL},
   {"sprite_edges",{(int*)&drawvars.sprite_edges, NULL},{RDRAW_MASKEDCOLUMNEDGE_SQUARE, NULL},
-   RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_none, NULL, NULL},
+   RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_gen, NULL, NULL},
   {"patch_edges",{(int*)&drawvars.patch_edges, NULL},{RDRAW_MASKEDCOLUMNEDGE_SQUARE, NULL},
-   RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_none, NULL, NULL},
+   RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_gen, NULL, NULL},
 
 
   {"Mouse settings",{NULL, NULL},{0, NULL},UL,UL,def_none,ss_none, NULL, NULL},

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -46,6 +46,8 @@ boolean M_WriteFile (char const* name,void* source,int length);
 
 int M_ReadFile (char const* name, uint8_t** buffer);
 
+void M_LoadDefaultsFile (char *file, boolean basedefault);
+
 void M_LoadDefaults (void);
 
 void M_SaveDefaults (void);


### PR DESCRIPTION
While I like how #45 uses the save folder to store the configuration, it also made it impossible to share the same configuration between WADs. This means every time you want to try out a new WAD you have to re-configure your set up. This would be ok if it wasn't because Doom has hundreds and hundreds of custom WADs by the community, it gets very annoying to have to set up the configuration every time.

With this change, the default values for the PrBoom configuration options will be loaded from prboom.cfg files found in the WAD folder or in the system folder (whatever is found first).

These are only affecting the default values, the user configured values would still be kept in the prboom.cfg file inside the save folder.

This way multiple wads will be able to share the same set of default values while still being able to keep separate configuration files and still allow the user to keep their settings in the respective save folders.

For some PWADs which might need specific configurations (such as loading multiple other WAD files like in #72 or even maybe more than one DEH file) this also allows storing and distributing a default config file with the WAD, so the WAD can be opened and have it work with the right settings without changing the saved user configuration.

With that intent in mind I also made it so that if there's a file next to the WAD that has the same name but with extension ".prboom.cfg", it'll be loaded as the base default config for that WAD (instead of looking for "prboom.cfg" within the system directory or parent directories).

For example, for WolfenDoom (as in #72) you could have the following files:
* orig15.wad
* original.wad
* original.deh
* original.prboom.cfg

Where the content of `original.prboom.cfg` would be:

```
# ORIG15 WAD contains extra lumps to load with PrBoom for WolfenDoom original levels
wadfile_1  "orig15.wad"
```
That would be enough so when `original.wad` is opened with the libretro core, also `orig15.wad` is loaded

I believe this also potentially fixes #57,  what do you think @Sakitoshi ?

I've also made a commit to fix #54

And the related issue #2 was fixed for some time now.. so I'm saying "fix #2" just to close it :P