### PR TITLE
Prevent endless loop lockup

### DIFF
--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -120,6 +120,9 @@ static float fast_sqrt(float n)
 	float		prev = 0.0f;
 	float		cur  = 1.0f;
 
+	if (n == 0)
+		return 0;
+
 	while (prev != cur)
 	{
 		prev = cur;


### PR DESCRIPTION
This fixes [Eviternity.wad](https://www.doomworld.com/forum/topic/103425-final-release-eviternity/), which was crashing because of it.
And it's one of the best boom-compatible wads from last year.

It's possible it could have been causing hangups for other wads too.