### PR TITLE
fix analog_turn_speed run key

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -957,7 +957,7 @@ static void process_gamepad_right_analog(void)
 	if (doom_devices[0] == RETROPAD_CLASSIC)
 		run_key = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
 	else if (doom_devices[0] == RETROPAD_MODERN)
-		run_key = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L);
+		run_key = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2);
 	else
 		run_key = 0;
 


### PR DESCRIPTION
With the last change to the modern layout, the run button was changed, but the function that makes the analog turn faster when holding the run button (or at normal speed if auto-run was active) wasn't updated to reflect that change. this fixes that.