### PR TITLE
Support SIGIL (Episode 5) & up to 7 Episodes

### DIFF
--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -249,6 +249,15 @@ const char *s_HUSTR_E4M6  = HUSTR_E4M6;
 const char *s_HUSTR_E4M7  = HUSTR_E4M7;
 const char *s_HUSTR_E4M8  = HUSTR_E4M8;
 const char *s_HUSTR_E4M9  = HUSTR_E4M9;
+const char *s_HUSTR_E5M1  = HUSTR_E5M1;
+const char *s_HUSTR_E5M2  = HUSTR_E5M2;
+const char *s_HUSTR_E5M3  = HUSTR_E5M3;
+const char *s_HUSTR_E5M4  = HUSTR_E5M4;
+const char *s_HUSTR_E5M5  = HUSTR_E5M5;
+const char *s_HUSTR_E5M6  = HUSTR_E5M6;
+const char *s_HUSTR_E5M7  = HUSTR_E5M7;
+const char *s_HUSTR_E5M8  = HUSTR_E5M8;
+const char *s_HUSTR_E5M9  = HUSTR_E5M9;
 const char *s_HUSTR_1     = HUSTR_1;
 const char *s_HUSTR_2     = HUSTR_2;
 const char *s_HUSTR_3     = HUSTR_3;
@@ -395,6 +404,7 @@ const char *s_E1TEXT     = E1TEXT;
 const char *s_E2TEXT     = E2TEXT;
 const char *s_E3TEXT     = E3TEXT;
 const char *s_E4TEXT     = E4TEXT;
+const char *s_E5TEXT     = E5TEXT;
 const char *s_C1TEXT     = C1TEXT;
 const char *s_C2TEXT     = C2TEXT;
 const char *s_C3TEXT     = C3TEXT;
@@ -436,6 +446,7 @@ const char *bgflatE1     = "FLOOR4_8"; // end of DOOM Episode 1
 const char *bgflatE2     = "SFLR6_1";  // end of DOOM Episode 2
 const char *bgflatE3     = "MFLR8_4";  // end of DOOM Episode 3
 const char *bgflatE4     = "MFLR8_3";  // end of DOOM Episode 4
+const char *bgflatE5     = "FLOOR4_8"; // end of DOOM Episode 5 (SIGIL)
 const char *bgflat06     = "SLIME16";  // DOOM2 after MAP06
 const char *bgflat11     = "RROCK14";  // DOOM2 after MAP11
 const char *bgflat20     = "RROCK07";  // DOOM2 after MAP20
@@ -591,6 +602,15 @@ static deh_strs deh_strlookup[] = { // not const any more, because of orig.
   {&s_HUSTR_E4M7,"HUSTR_E4M7", NULL},
   {&s_HUSTR_E4M8,"HUSTR_E4M8", NULL},
   {&s_HUSTR_E4M9,"HUSTR_E4M9", NULL},
+  {&s_HUSTR_E5M1,"HUSTR_E5M1", NULL},
+  {&s_HUSTR_E5M2,"HUSTR_E5M2", NULL},
+  {&s_HUSTR_E5M3,"HUSTR_E5M3", NULL},
+  {&s_HUSTR_E5M4,"HUSTR_E5M4", NULL},
+  {&s_HUSTR_E5M5,"HUSTR_E5M5", NULL},
+  {&s_HUSTR_E5M6,"HUSTR_E5M6", NULL},
+  {&s_HUSTR_E5M7,"HUSTR_E5M7", NULL},
+  {&s_HUSTR_E5M8,"HUSTR_E5M8", NULL},
+  {&s_HUSTR_E5M9,"HUSTR_E5M9", NULL},
   {&s_HUSTR_1,"HUSTR_1", NULL},
   {&s_HUSTR_2,"HUSTR_2", NULL},
   {&s_HUSTR_3,"HUSTR_3", NULL},
@@ -736,6 +756,7 @@ static deh_strs deh_strlookup[] = { // not const any more, because of orig.
   {&s_E2TEXT,"E2TEXT", NULL},
   {&s_E3TEXT,"E3TEXT", NULL},
   {&s_E4TEXT,"E4TEXT", NULL},
+  {&s_E5TEXT,"E5TEXT", NULL},
   {&s_C1TEXT,"C1TEXT", NULL},
   {&s_C2TEXT,"C2TEXT", NULL},
   {&s_C3TEXT,"C3TEXT", NULL},
@@ -775,6 +796,7 @@ static deh_strs deh_strlookup[] = { // not const any more, because of orig.
   {&bgflatE2,"BGFLATE2", NULL},
   {&bgflatE3,"BGFLATE3", NULL},
   {&bgflatE4,"BGFLATE4", NULL},
+  {&bgflatE5,"BGFLATE5", NULL},
   {&bgflat06,"BGFLAT06", NULL},
   {&bgflat11,"BGFLAT11", NULL},
   {&bgflat20,"BGFLAT20", NULL},

--- a/src/d_deh.h
+++ b/src/d_deh.h
@@ -343,6 +343,26 @@ extern const char *s_HUSTR_E4M8; // = HUSTR_E4M8;
 //#define HUSTR_E4M9    "E4M9: Fear"
 extern const char *s_HUSTR_E4M9; // = HUSTR_E4M9;
 
+
+//#define HUSTR_E5M1  "E5M1: Baphomet's Demesne";
+extern const char *s_HUSTR_E5M1; // = HUSTR_E5M1;
+//#define HUSTR_E5M2  "E5M2: Sheol";
+extern const char *s_HUSTR_E5M2; // = HUSTR_E5M2;
+//#define HUSTR_E5M3  "E5M3: Cages of the Damned";
+extern const char *s_HUSTR_E5M3; // = HUSTR_E5M3;
+//#define HUSTR_E5M4  "E5M4: Paths of Wretchedness";
+extern const char *s_HUSTR_E5M4; // = HUSTR_E5M4;
+//#define HUSTR_E5M5  "E5M5: Abaddon's Void";
+extern const char *s_HUSTR_E5M5; // = HUSTR_E5M5;
+//#define HUSTR_E5M6  "E5M6: Unspeakable Persecution";
+extern const char *s_HUSTR_E5M6; // = HUSTR_E5M6;
+//#define HUSTR_E5M7  "E5M7: Nightmare Underworld";
+extern const char *s_HUSTR_E5M7; // = HUSTR_E5M7;
+//#define HUSTR_E5M8  "E5M8: Halls of Perdition";
+extern const char *s_HUSTR_E5M8; // = HUSTR_E5M8;
+//#define HUSTR_E5M9  "E5M9: Realm of Iblis";
+extern const char *s_HUSTR_E5M9; // = HUSTR_E5M9
+
 //#define HUSTR_1       "level 1: entryway"
 extern const char *s_HUSTR_1; // = HUSTR_1;
 //#define HUSTR_2       "level 2: underhalls"
@@ -744,6 +764,19 @@ extern const char* s_E3TEXT; // = E3TEXT;
 */
 extern const char* s_E4TEXT; // = E4TEXT;
 
+/*
+#define E5TEXT \
+"Baphomet was only doing Satan's bidding\n"\
+"by bringing you back to Hell. Somehow they\n"\
+"didn't understand that you're the reason\n"\
+"they failed in the first place.\n\n"\
+"After mopping up the place with your\n"\
+"arsenal, you're ready to face the more\n"\
+"advanced demons that were sent to Earth.\n\n"\
+"Lock and load. Rip and tear."
+*/
+extern const char* s_E5TEXT; // = E5TEXT;
+
 
 // after level 6, put this:
 
@@ -1082,6 +1115,8 @@ extern const char* bgflatE2;
 extern const char* bgflatE3;
 // char*        bgflatE4 = "MFLR8_3";
 extern const char* bgflatE4;
+// char*        bgflatE5 = "FLOOR4_8";
+extern const char* bgflatE5;
 
 // char*        bgflat06 = "SLIME16";
 extern const char* bgflat06;

--- a/src/d_englsh.h
+++ b/src/d_englsh.h
@@ -187,6 +187,16 @@
 #define HUSTR_E4M8  "E4M8: Unto The Cruel"
 #define HUSTR_E4M9  "E4M9: Fear"
 
+#define HUSTR_E5M1  "E5M1: Baphomet's Demesne";
+#define HUSTR_E5M2  "E5M2: Sheol";
+#define HUSTR_E5M3  "E5M3: Cages of the Damned";
+#define HUSTR_E5M4  "E5M4: Paths of Wretchedness";
+#define HUSTR_E5M5  "E5M5: Abaddon's Void";
+#define HUSTR_E5M6  "E5M6: Unspeakable Persecution";
+#define HUSTR_E5M7  "E5M7: Nightmare Underworld";
+#define HUSTR_E5M8  "E5M8: Halls of Perdition";
+#define HUSTR_E5M9  "E5M9: Realm of Iblis";
+
 #define HUSTR_1     "level 1: entryway"
 #define HUSTR_2     "level 2: underhalls"
 #define HUSTR_3     "level 3: the gantlet"
@@ -445,6 +455,15 @@
   "\n"\
   "next stop, hell on earth!"
 
+#define E5TEXT \
+  "Baphomet was only doing Satan's bidding\n"\
+  "by bringing you back to Hell. Somehow they\n"\
+  "didn't understand that you're the reason\n"\
+  "they failed in the first place.\n\n"\
+  "After mopping up the place with your\n"\
+  "arsenal, you're ready to face the more\n"\
+  "advanced demons that were sent to Earth.\n\n"\
+  "Lock and load. Rip and tear."
 
 /* after level 6, put this: */
 

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -116,8 +116,14 @@ void F_StartFinale (void)
                  finaleflat = bgflatE4;
                  finaletext = s_E4TEXT;
                  break;
+              case 5:
+                 finaleflat = bgflatE5;
+                 finaletext = s_E5TEXT;
+                 break;
               default:
-                 // Ouch.
+                 // Some default values to avoid crashing on extra episodes
+                 finaleflat = bgflatE5;
+                 finaletext = "The End";
                  break;
            }
            break;
@@ -668,6 +674,9 @@ void F_Drawer (void)
            break;
       case 4:
            V_DrawNamePatch(0, 0, 0, "ENDPIC", CR_DEFAULT, VPT_STRETCH);
+           break;
+      case 5:
+           V_DrawNamePatch(0, 0, 0, "SIGILEND", CR_DEFAULT, VPT_STRETCH);
            break;
     }
   }

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -539,22 +539,16 @@ static void G_DoLoadLevel (void)
          if (gamemap < 21)
             skytexture = R_TextureNumForName ("SKY2");
    }
-   else /* jff 3/27/98 and lets not forget about DOOM and Ultimate DOOM huh? */
-      switch (gameepisode)
-      {
-         case 1:
-            skytexture = R_TextureNumForName ("SKY1");
-            break;
-         case 2:
-            skytexture = R_TextureNumForName ("SKY2");
-            break;
-         case 3:
-            skytexture = R_TextureNumForName ("SKY3");
-            break;
-         case 4: // Special Edition sky
-            skytexture = R_TextureNumForName ("SKY4");
-            break;
-      }//jff 3/27/98 end sky setting fix
+   else /* and lets not forget about DOOM, Ultimate DOOM, SIGIL & extra Eps */
+   {
+     // Each episode has its own sky, numbered after it
+     char skyname[9];
+     sprintf(skyname, "SKY%d", gameepisode);
+     skytexture = R_CheckTextureNumForName(skyname);
+     if (skytexture == -1)
+       // default sky, in case of custom episodes with missing SKY
+       skytexture = R_TextureNumForName ("SKY1");
+   }
 
    /* cph 2006/07/31 - took out unused levelstarttic variable */
 
@@ -1334,6 +1328,9 @@ void G_DoCompleted (void)
               case 4:
                 wminfo.next = 2;
                 break;
+              case 5:
+                wminfo.next = 6;
+                break;
               }
           }
         else
@@ -2112,8 +2109,8 @@ void G_InitNew(skill_t skill, int episode, int map)
 
   if (gamemode == retail)
     {
-      if (episode > 4)
-        episode = 4;
+      if (episode > MAX_EPISODE_NUM)
+        episode = MAX_EPISODE_NUM;
     }
   else
     if (gamemode == shareware)

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -43,6 +43,9 @@
 // killough 5/2/98: number of bytes reserved for saving options
 #define GAME_OPTION_SIZE 64
 
+// maximum number of episodes
+#define MAX_EPISODE_NUM 7
+
 boolean G_Responder(event_t *ev);
 boolean G_CheckDemoStatus(void);
 void G_DeathMatchSpawnPlayer(int playernum);

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -427,7 +427,7 @@ static void cheat_clev(char buf[3])
 
   // Catch invalid maps.
   if (epsd < 1 || map < 1 ||   // Ohmygod - this is not going to work.
-      (gamemode == retail     && (epsd > 4 || map > 9  )) ||
+      (gamemode == retail     && (epsd > 5 || map > 9  )) || // allow sigil
       (gamemode == registered && (epsd > 3 || map > 9  )) ||
       (gamemode == shareware  && (epsd > 1 || map > 9  )) ||
       (gamemode == commercial && (epsd > 1 || map > 33 )) )  //jff no 33 and 34

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -495,21 +495,6 @@ void M_DrawReadThis2(void)
 // EPISODE SELECT
 //
 
-//
-// episodes_e provides numbers for the episode menu items. The default is
-// 4, to accomodate Ultimate Doom. If the user is running anything else,
-// this is accounted for in the code.
-//
-
-enum
-{
-  ep1,
-  ep2,
-  ep3,
-  ep4,
-  ep_end
-} episodes_e;
-
 // The definitions of the Episodes menu
 
 menuitem_t EpisodeMenu[]=
@@ -517,17 +502,20 @@ menuitem_t EpisodeMenu[]=
   {1,"M_EPI1", M_Episode,'k'},
   {1,"M_EPI2", M_Episode,'t'},
   {1,"M_EPI3", M_Episode,'i'},
-  {1,"M_EPI4", M_Episode,'t'}
+  {1,"M_EPI4", M_Episode,'t'},
+  {1,"M_EPI5", M_Episode,'s'},
+  {1,"M_EPI6", M_Episode,'6'},
+  {1,"M_EPI7", M_Episode,'7'}
 };
 
 menu_t EpiDef =
 {
-  ep_end,        // # of menu items
+  0,             // # of menu items ( will be set in M_Init )
   &MainDef,      // previous menu
   EpisodeMenu,   // menuitem_t ->
   M_DrawEpisode, // drawing routine ->
   48,63,         // x,y
-  ep1            // lastOn
+  0              // lastOn
 };
 
 //
@@ -538,7 +526,7 @@ int epi;
 void M_DrawEpisode(void)
 {
   // CPhipps - patch drawing updated
-  V_DrawNamePatch(54, 38, 0, "M_EPISOD", CR_DEFAULT, VPT_STRETCH);
+  V_DrawNamePatch(54, EpiDef.y - 25, 0, "M_EPISOD", CR_DEFAULT, VPT_STRETCH);
 }
 
 void M_Episode(int choice)
@@ -548,14 +536,6 @@ void M_Episode(int choice)
     M_SetupNextMenu(&ReadDef1);
     return;
   }
-
-  // Yet another hack...
-  if ( (gamemode == registered) && (choice > 2))
-    {
-    lprintf( LO_WARN,
-     "M_Episode: 4th episode requires UltimateDOOM\n");
-    choice = 0;
-    }
 
   epi = choice;
   M_SetupNextMenu(&NewDef);
@@ -5364,12 +5344,21 @@ void M_Init(void)
       // killough 10/98: moved to second screen, moved up to the top
       ReadDef2.y = 15;
 
-    case shareware:
-      // We need to remove the fourth episode.
-      EpiDef.numitems--;
-      break;
+      // fall through
     case retail:
-      // We are fine.
+      // Check until which episode are there maps available
+      for(EpiDef.numitems = 0; EpiDef.numitems < MAX_EPISODE_NUM; EpiDef.numitems++) {
+        char mapname[9];
+        sprintf(mapname, "E%dM1", EpiDef.numitems + 1);
+        if (W_CheckNumForName(mapname) == -1) {
+           break;
+        }
+      }
+      break;
+    case shareware:
+      // Shareware version should only have 3 entries
+      EpiDef.numitems = 3;
+      break;
     default:
       break;
     }

--- a/src/wi_stuff.c
+++ b/src/wi_stuff.c
@@ -418,6 +418,15 @@ static void WI_slamBackground(void)
   else
     sprintf(name, "WIMAP%d", wbs->epsd);
 
+
+  if (W_CheckNumForName(name) == -1) {
+    if ((wbs->epsd == 4) && (W_CheckNumForName("SIGILINT") != -1))
+      // SIGIL support
+      strcpy(name, "SIGILINT");
+    else
+      // default intermission for extra custom episodes
+      strcpy(name, "INTERPIC");
+  }
   // background
   V_DrawNamePatch(0, 0, FB, name, CR_DEFAULT, VPT_STRETCH);
 }


### PR DESCRIPTION
Recently Romero released a 5th Episode for the original Doom: SIGIL (https://www.romerogames.ie/si6il)
On May 31st it will be a free download for everyone.
The release comes with a "SIGIL_COMPAT" WAD that replaces Episode 3 for engines that do not support a 5th episode, but with this commit we will also have support for the original Episode 5, and the finale texts and map names as included in the release.

The change also allows for more custom episodes to be added, up to 7, as long as there are maps included named E4M1, E5M1, E6M1 or E7M1. Although I didn't add Dehacked entries to change the titles and texts for episodes 6 and 7 (it would be easy to add however).

Note however that the Episode count will stop as soon as there's a gap, which means the 5th episode entry would only appear when loaded with ultimate Doom that includes episode 4.