### PR TITLE
Fine tune OPL output level

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -34,7 +34,7 @@
 
 //i_system
 int ms_to_next_tick;
-int mus_opl_gain = 50; // NSM  fine tune OPL output level
+int mus_opl_gain = 250; // fine tune OPL output level
 
 int SCREENWIDTH  = 320;
 int SCREENHEIGHT = 200;

--- a/src/oplplayer.c
+++ b/src/oplplayer.c
@@ -523,14 +523,18 @@ static void SetVoiceVolume(opl_voice_t *voice, unsigned int volume)
                    * volume_mapping_table[voice->channel->volume]
                    * volume_mapping_table[current_music_volume]) / (127 * 127);
 
-    // The volume of each instrument can be controlled via GENMIDI:
+    if (full_volume > 0)
+    {
+       // The volume of each instrument can be controlled via GENMIDI:
+       op_volume = 0x3f - opl_voice->carrier.level;
 
-    op_volume = 0x3f - opl_voice->carrier.level;
+       // The volume value to use in the register:
 
-    // The volume value to use in the register:
-
-    reg_volume = (op_volume * full_volume) / 128;
-    reg_volume = (0x3f - reg_volume) | opl_voice->carrier.scale;
+       reg_volume = (op_volume * full_volume) / 128;
+       reg_volume = (0x3f - reg_volume) | opl_voice->carrier.scale;
+    }
+    else
+       reg_volume = 0xff;
 
     // Update the volume register(s) if necessary.
 


### PR DESCRIPTION
This is a small tweak to the gain of the OPL player.
The sound was very low otherwise, this brings the volume up to a more comparable level as the mp3 music and the sound effects on the same settings.

Also the music was still playing at a low volume even with volume set to zero, this should fix it.