### PR TITLE
Add Freelook Support

### DIFF
--- a/src/d_player.h
+++ b/src/d_player.h
@@ -183,9 +183,9 @@ typedef struct player_s
   /* used for interpolation */
   fixed_t prev_viewz;
   angle_t prev_viewangle;
+  angle_t prev_viewpitch;
 
 } player_t;
-
 
 //
 // INTERMISSION

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -180,6 +180,7 @@ extern  boolean paused;        // Game Pause?
 // This one is related to the 3-screen display mode.
 // ANG90 = left side, ANG270 = right
 extern  int viewangleoffset;
+extern  int viewpitchoffset;
 
 // Player taking events, and displaying.
 extern  int consoleplayer;
@@ -247,6 +248,9 @@ extern  gamestate_t     wipegamestate;
 
 extern  int             mouseSensitivity_horiz; // killough
 extern  int             mouseSensitivity_vert;
+
+extern  boolean         movement_mouselook;
+extern  boolean         movement_mouseinvert;
 
 extern  int             bodyqueslot;
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -206,6 +206,7 @@ int     mousebfire;
 int     mousebstrafe;
 int     mousebforward;
 int     mousebbackward;
+int     mlooky;
 
 #define MAXPLMOVE   (forwardmove[1])
 #define TURBOTHRESHOLD  0x32
@@ -471,6 +472,14 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   else
     cmd->angleturn -= mousex; /* mead now have enough dynamic range 2-10-00 */
 
+  // if mouselook enabled, set pitch without affecting the tic cmds
+  if (movement_mouselook) {
+     if (movement_mouseinvert)
+        mlooky -= mousey;
+     else
+        mlooky += mousey;
+  }
+
   mousex = mousey = 0;
 
   if (forward > MAXPLMOVE)
@@ -605,6 +614,7 @@ static void G_DoLoadLevel (void)
    /* clear cmd building stuff */
    memset (gamekeydown, 0, sizeof(gamekeydown));
    mousex = mousey = 0;
+   mlooky = 0;
    special_event = 0; paused = FALSE;
    memset (mousebuttons, 0, sizeof(*mousebuttons));
 

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -166,6 +166,7 @@ extern int  mousebstrafe;
 extern int  mousebforward;
 extern int  mousebbackward;
 extern int  mouse_double_click_use;
+extern int  mlooky;
 
 extern int  defaultskill;      //jff 3/24/98 default skill
 extern boolean haswolflevels;  //jff 4/18/98 wolf levels present

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2759,26 +2759,24 @@ setup_menu_t* gen_settings[] =
 };
 
 enum {
-  general_trans,
-  general_transpct,
-//  general_pcx,
-//  general_diskicon,
-  general_uncapped,
-  general_gamma
-};
+  general_title_video,
+  general_fps,
+  general_gamma,
 
-enum {
-//  general_sndcard,
-//  general_muscard,
-//  general_detvoices,
+  general_title_sound,
   general_sndchan,
-  general_pitch
+  general_pitch,
+
+  general_title_freelook,
+  general_mouselook,
+  general_mouseinvert,
+  general_maxviewpitch,
 };
 
 #define G_X 250
 #define G_YA  44
-#define G_YA2 (G_YA+9*8)
-#define G_YA3 (G_YA2+5*8)
+#define G_YA2 (G_YA + 16)
+#define G_YA3 (G_YA2 + 16)
 #define GF_X 76
 
 static const char *framerates[] = {"35fps", "40fps", "50fps", "60fps", "70fps", "72fps", "75fps", "100fps", "119fps", "120fps", "140fps", "144fps"};
@@ -2786,41 +2784,34 @@ static const char *gamma_lvls[] = {"OFF", "Lv. 1", "Lv. 2", "Lv. 3", "Lv. 4"};
 
 setup_menu_t gen_settings1[] = { // General Settings screen1
 
-  {"Video"       ,S_SKIP|S_TITLE, m_null, G_X, G_YA - 12},
+  {"Video"       ,S_SKIP|S_TITLE, m_null, G_X, G_YA - 2},
 
   {"Framerate", S_CHOICE, m_null, G_X,
-  G_YA + general_uncapped*8, {"uncapped_framerate"}, 0, 0, M_ChangeFramerate, framerates},
+  G_YA + general_fps*8, {"uncapped_framerate"}, 0, 0, M_ChangeFramerate, framerates},
 
   {"Gamma Correction", S_CHOICE, m_null, G_X,
   G_YA + general_gamma*8, {"usegamma"}, 0, 0, NULL, gamma_lvls},
 
-#if 0
-  {"PCX instead of BMP for screenshots", S_YESNO, m_null, G_X,
-   G_YA + general_pcx*8, {"screenshot_pcx"}},
-#endif
 
-#if 0 // MBF
-  {"Flash Icon During Disk IO", S_YESNO, m_null, G_X,
-   G_YA + general_diskicon*8, {"disk_icon"}},
-#endif
-
-  {"Sound & Music", S_SKIP|S_TITLE, m_null, G_X, G_YA3 - 12},
-#if 0 // MBF
-  {"Sound Card", S_NUM|S_PRGWARN, m_null, G_X,
-   G_YA2 + general_sndcard*8, {"sound_card"}},
-
-  {"Music Card", S_NUM|S_PRGWARN, m_null, G_X,
-   G_YA2 + general_muscard*8, {"music_card"}},
-
-  {"Autodetect Number of Voices", S_YESNO|S_PRGWARN, m_null, G_X,
-   G_YA2 + general_detvoices*8, {"detect_voices"}},
-#endif
+  {"Sound & Music", S_SKIP|S_TITLE, m_null, G_X, G_YA2 + general_title_sound*8 - 2},
 
   {"Number of Sound Channels", S_NUM|S_PRGWARN, m_null, G_X,
-   G_YA3 + general_sndchan*8, {"snd_channels"}},
+   G_YA2 + general_sndchan*8, {"snd_channels"}},
 
   {"Enable v1.1 Pitch Effects", S_YESNO, m_null, G_X,
-   G_YA3 + general_pitch*8, {"pitched_sounds"}},
+   G_YA2 + general_pitch*8, {"pitched_sounds"}},
+
+
+  {"Freelook"  ,S_SKIP|S_TITLE, m_null, G_X, G_YA3 + general_title_freelook*8 - 2},
+
+  {"Enable Vertical Mouse Look", S_YESNO, m_null, G_X,
+   G_YA3 + general_mouselook*8, {"movement_mouselook"}, 0, 0, M_ChangeMouseLook},
+
+  {"Invert Vertical Mouse", S_YESNO, m_null, G_X,
+   G_YA3 + general_mouseinvert*8, {"movement_mouseinvert"}, 0, 0, NULL},
+
+  {"Maximum Vertical Pitch", S_NUM, m_null, G_X,
+   G_YA3 + general_maxviewpitch*8, {"movement_maxviewpitch"}, 0, 0, M_ChangeMaxViewPitch},
 
   // Button for resetting to defaults
   {0,S_RESET,m_null,X_BUTTON,Y_BUTTON},
@@ -2832,28 +2823,22 @@ setup_menu_t gen_settings1[] = { // General Settings screen1
 };
 
 enum {
+  general_title_preload,
   general_wad1,
   general_wad2,
   general_deh1,
-  general_deh2
-};
+  general_deh2,
 
-enum {
+  general_title_misc,
   general_corpse,
   general_smooth,
   general_smoothfactor,
   general_defskill,
 };
 
-enum {
-  general_mouselook,
-  general_mouseinvert,
-  general_maxviewpitch,
-};
 
-#define G_YB  44
-#define G_YB1 (G_YB+44)
-#define G_YB2 (G_YB1+52)
+#define G_YB  60
+#define G_YB1 (G_YB+20)
 
 static const char *gen_skillstrings[] = {
   // Dummy first option because defaultskill is 1-based
@@ -2862,15 +2847,14 @@ static const char *gen_skillstrings[] = {
 
 setup_menu_t gen_settings2[] = { // General Settings screen2
 
-  {"Files Preloaded at Game Startup",S_SKIP|S_TITLE, m_null, G_X,
-   G_YB - 12},
+  {"Files Preloaded at Game Startup",S_SKIP|S_TITLE, m_null, G_X, G_YB - 2},
 
   {"WAD # 1",     S_FILE, m_null, GF_X, G_YB + general_wad1*8, {"wadfile_1"}},
   {"WAD #2",      S_FILE, m_null, GF_X, G_YB + general_wad2*8, {"wadfile_2"}},
   {"DEH/BEX # 1", S_FILE, m_null, GF_X, G_YB + general_deh1*8, {"dehfile_1"}},
   {"DEH/BEX #2",  S_FILE, m_null, GF_X, G_YB + general_deh2*8, {"dehfile_2"}},
 
-  {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, G_X, G_YB1 - 12},
+  {"Miscellaneous"  ,S_SKIP|S_TITLE, m_null, G_X, G_YB1 + general_title_misc*8 - 2},
 
   {"Maximum number of player corpses", S_NUM|S_PRGWARN, m_null, G_X,
    G_YB1 + general_corpse*8, {"max_player_corpse"}},
@@ -2884,17 +2868,6 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
   {"Default skill level", S_CHOICE, m_null, G_X,
     G_YB1 + general_defskill*8, {"default_skill"}, 0, 0, NULL, gen_skillstrings},
 
-  {"Freelook"  ,S_SKIP|S_TITLE, m_null, G_X, G_YB2 - 12},
-
-  {"Enable Vertical Mouse Look", S_YESNO, m_null, G_X,
-   G_YB2 + general_mouselook*8, {"movement_mouselook"}, 0, 0, M_ChangeMouseLook},
-
-  {"Invert Vertical Mouse", S_YESNO, m_null, G_X,
-   G_YB2 + general_mouseinvert*8, {"movement_mouseinvert"}, 0, 0, NULL},
-
-  {"Maximum Vertical Pitch", S_NUM, m_null, G_X,
-   G_YB2 + general_maxviewpitch*8, {"movement_maxviewpitch"}, 0, 0, M_ChangeMaxViewPitch},
-
   {"<- PREV",S_SKIP|S_PREV, m_null, KB_PREV, KB_Y+20*8, {gen_settings1}},
 
   {"NEXT ->",S_SKIP|S_NEXT,m_null,KB_NEXT,KB_Y+20*8, {gen_settings3}},
@@ -2905,29 +2878,30 @@ setup_menu_t gen_settings2[] = { // General Settings screen2
 };
 
 enum {
+  general_title_display,
   general_filterwall,
   general_filterfloor,
   general_filtersprite,
   general_filterpatch,
   general_filterz,
-  general_filter_threshold,
   general_spriteedges,
   general_patchedges,
   general_hom,
   general_skystretch,
-  general_gap_settings3,
   general_menubg,
 };
 
 
 #define G_YC  44
+#define G_YC2 (G_YC+6)
+#define G_YC3 (G_YC2+6)
 
 static const char *renderfilters[] = {"none", "point", "linear", "rounded"};
 static const char *edgetypes[] = {"jagged", "sloped"};
 
 setup_menu_t gen_settings3[] = { // General Settings screen2
 
-  {"Display options"     ,S_SKIP|S_TITLE, m_null, G_X, G_YB - 12},
+  {"Display options"     ,S_SKIP|S_TITLE, m_null, G_X, G_YC - 2},
 
   {"Filter for walls", S_CHOICE, m_null, G_X,
    G_YC + general_filterwall*8, {"filter_wall"}, 0, 0, NULL, renderfilters},
@@ -2951,13 +2925,13 @@ setup_menu_t gen_settings3[] = { // General Settings screen2
    G_YC + general_patchedges*8, {"patch_edges"}, 0, 0, NULL, edgetypes},
 
   {"Flashing HOM indicator", S_YESNO, m_null, G_X,
-   G_YC + general_hom*8, {"flashing_hom"}},
+   G_YC2 + general_hom*8, {"flashing_hom"}},
 
   {"Stretch sky on freelook", S_YESNO, m_null, G_X,
-   G_YC + general_skystretch*8, {"render_stretchsky"}, 0, 0, M_ChangeMouseLook},
+   G_YC2 + general_skystretch*8, {"render_stretchsky"}, 0, 0, M_ChangeMouseLook},
 
   {"Fullscreen menu background", S_YESNO, m_null, G_X,
-   G_YC + general_menubg*8, {"menu_background"}},
+   G_YC3 + general_menubg*8, {"menu_background"}},
 
   {"<- PREV",S_SKIP|S_PREV, m_null, KB_PREV, KB_Y+20*8, {gen_settings2}},
 
@@ -2969,9 +2943,9 @@ setup_menu_t gen_settings3[] = { // General Settings screen2
 void M_ChangeDemoSmoothTurns(void)
 {
   if (demo_smoothturns)
-    gen_settings2[12].m_flags &= ~(S_SKIP|S_SELECT);
+    gen_settings2[general_smoothfactor].m_flags &= ~(S_SKIP|S_SELECT);
   else
-    gen_settings2[12].m_flags |= (S_SKIP|S_SELECT);
+    gen_settings2[general_smoothfactor].m_flags |= (S_SKIP|S_SELECT);
 
   R_SmoothPlaying_Reset(NULL);
 }
@@ -2984,6 +2958,15 @@ void M_ChangeFramerate(void)
 
 void M_ChangeMouseLook(void)
 {
+  if (movement_mouselook) {
+    gen_settings1[general_mouseinvert].m_flags  &= ~(S_SKIP|S_SELECT);
+    gen_settings1[general_maxviewpitch].m_flags &= ~(S_SKIP|S_SELECT);
+    gen_settings3[general_skystretch].m_flags   &= ~(S_SKIP|S_SELECT);
+  } else {
+    gen_settings1[general_mouseinvert].m_flags  |= (S_SKIP|S_SELECT);
+    gen_settings1[general_maxviewpitch].m_flags |= (S_SKIP|S_SELECT);
+    gen_settings3[general_skystretch].m_flags   |= (S_SKIP|S_SELECT);
+  }
   R_InitSkyMap();
   viewpitch = 0;
 }

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -318,7 +318,7 @@ default_t defaults[] =
    def_bool,ss_gen, NULL, NULL}, // enables use of mouselook
   {"movement_mouseinvert",{&movement_mouseinvert, NULL},{0, NULL},0,1,
    def_bool,ss_gen, NULL, NULL}, // whether to invert the mouse vertical 
-  {"movement_maxviewpitch",{&movement_maxviewpitch, NULL},{36, NULL},0,80,
+  {"movement_maxviewpitch",{&movement_maxviewpitch, NULL},{32, NULL},0,80,
    def_int,ss_gen, NULL, NULL}, // maximum/minimum pitch when looking up and down
 
 // For key bindings, the values stored in the key_* variables       // phares

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -261,10 +261,6 @@ default_t defaults[] =
      0,1,def_bool,ss_comp,&comp[comp_maskedanim], NULL},
 
   {"Sound settings",{NULL},{0},UL,UL,def_none,ss_none, NULL, NULL},
-  {"sound_card",{&snd_card, NULL},{-1, NULL},-1,7,       // jff 1/18/98 allow Allegro drivers
-   def_int,ss_none, NULL, NULL}, // select sounds driver (DOS), -1 is autodetect, 0 is none; in Linux, non-zero enables sound
-  {"music_card",{&mus_card, NULL},{-1, NULL},-1,9,       //  to be set,  -1 = autodetect
-   def_int,ss_none, NULL, NULL}, // select music driver (DOS), -1 is autodetect, 0 is none"; in Linux, non-zero enables music
   {"pitched_sounds",{&pitched_sounds, NULL},{0, NULL},0,1, // killough 2/21/98
    def_bool,ss_gen, NULL, NULL}, // enables variable pitch in sound effects (from id's original code)
   {"samplerate",{&snd_samplerate, NULL},{11025, NULL},11025,48000, def_int,ss_none, NULL, NULL},
@@ -318,7 +314,7 @@ default_t defaults[] =
   {"mouseb_backward",{&mousebbackward, NULL},{-1, NULL},-1,MAX_MOUSEB,
    def_int,ss_keys, NULL, NULL}, // mouse button number to use for backward motion
   // Freelook settings
-  {"movement_mouselook",{&movement_mouselook, NULL},{1, NULL},0,1,
+  {"movement_mouselook",{&movement_mouselook, NULL},{0, NULL},0,1,
    def_bool,ss_gen, NULL, NULL}, // enables use of mouselook
   {"movement_mouseinvert",{&movement_mouseinvert, NULL},{0, NULL},0,1,
    def_bool,ss_gen, NULL, NULL}, // whether to invert the mouse vertical 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -66,6 +66,7 @@
 #include "r_draw.h"
 #include "r_demo.h"
 #include "r_fps.h"
+#include "r_sky.h"
 
 #ifdef _WIN32
    #define DIR_SLASH_STR "\\"
@@ -142,6 +143,8 @@ extern int tran_filter_pct;            // killough 2/21/98
 
 extern int screenblocks;
 extern int showMessages;
+
+extern int movement_maxviewpitch;
 
 int         mus_pause_opt; // 0 = kill music, 1 = pause, 2 = continue
 
@@ -295,11 +298,10 @@ default_t defaults[] =
    RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_gen, NULL, NULL},
   {"patch_edges",{(int*)&drawvars.patch_edges, NULL},{RDRAW_MASKEDCOLUMNEDGE_SQUARE, NULL},
    RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_gen, NULL, NULL},
-
+  {"render_stretchsky",{&r_stretchsky, NULL},{1, NULL},0,1,
+   def_bool,ss_gen,NULL, NULL},
 
   {"Mouse settings",{NULL, NULL},{0, NULL},UL,UL,def_none,ss_none, NULL, NULL},
-  {"use_mouse",{&usemouse, NULL},{1, NULL},0,1,
-   def_bool,ss_none, NULL, NULL}, // enables use of mouse with DOOM
   //jff 4/3/98 allow unlimited sensitivity
   {"mouse_sensitivity_horiz",{&mouseSensitivity_horiz, NULL},{40, NULL},0,UL,
    def_int,ss_none, NULL, NULL}, /* adjust horizontal (x) mouse sensitivity killough/mead */
@@ -315,6 +317,13 @@ default_t defaults[] =
    def_int,ss_keys, NULL, NULL}, // mouse button number to use for forward motion
   {"mouseb_backward",{&mousebbackward, NULL},{-1, NULL},-1,MAX_MOUSEB,
    def_int,ss_keys, NULL, NULL}, // mouse button number to use for backward motion
+  // Freelook settings
+  {"movement_mouselook",{&movement_mouselook, NULL},{1, NULL},0,1,
+   def_bool,ss_gen, NULL, NULL}, // enables use of mouselook
+  {"movement_mouseinvert",{&movement_mouseinvert, NULL},{0, NULL},0,1,
+   def_bool,ss_gen, NULL, NULL}, // whether to invert the mouse vertical 
+  {"movement_maxviewpitch",{&movement_maxviewpitch, NULL},{36, NULL},0,80,
+   def_int,ss_gen, NULL, NULL}, // maximum/minimum pitch when looking up and down
 
 // For key bindings, the values stored in the key_* variables       // phares
 // are the internal Doom Codes. The values stored in the default.cfg

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -1675,10 +1675,12 @@ void A_VileChase(mobj_t* actor)
       corpsehit->flags =
         (info->flags & ~MF_FRIEND) | (actor->flags & MF_FRIEND);
 
-		  if (!((corpsehit->flags ^ MF_COUNTKILL) & (MF_FRIEND | MF_COUNTKILL)))
-		    totallive++;
-		  
-                  corpsehit->health = info->spawnhealth;
+      corpsehit->flags = corpsehit->flags | MF_RESURRECTED;//mark as resurrected
+
+      if (!((corpsehit->flags ^ MF_COUNTKILL) & (MF_FRIEND | MF_COUNTKILL)))
+          totallive++;
+
+      corpsehit->health = info->spawnhealth;
       P_SetTarget(&corpsehit->target, NULL);  // killough 11/98
 
       if (mbf_features)

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -218,6 +218,16 @@
 #define MF_BOUNCES         LONGLONG(0x0000000200000000)
 #define MF_FRIEND          LONGLONG(0x0000000400000000)
 
+#define MF_RESURRECTED     LONGLONG(0x0000001000000000)
+// unused, just for prboom-plus compatibility (see https://github.com/coelckers/prboom-plus/commit/ec2c18 )
+#define MF_NO_DEPTH_TEST   LONGLONG(0x0000002000000000)
+// unused, just for prboom-plus compatibility (see https://github.com/coelckers/prboom-plus/commit/865329 )
+#define MF_FOREGROUND      LONGLONG(0x0000004000000000)
+
+#define MF_PLAYERSPRITE LONGLONG(0x0000008000000000)
+
+#define ALIVE(thing) ((thing->health > 0) && ((thing->flags & (MF_COUNTKILL | MF_CORPSE | MF_RESURRECTED)) == MF_COUNTKILL))
+
 // killough 9/15/98: Same, but internal flags, not intended for .deh
 // (some degree of opaqueness is good, to avoid compatibility woes)
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -270,7 +270,8 @@ typedef struct mobj_s
     struct mobj_s**     sprev; // killough 8/10/98: change to ptr-to-ptr
 
     //More drawing info: to determine current sprite.
-    angle_t             angle;  // orientation
+    angle_t             angle;  // orientation (yaw)
+    angle_t             pitch;  // looking up/down angle
     spritenum_t         sprite; // used to find patch_t and flip value
     int                 frame;  // might be ORed with FF_FULLBRIGHT
 

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -353,8 +353,6 @@ typedef struct vissprite_s
 
   // killough 3/27/98: height sector for underwater/fake ceiling support
   int heightsec;
-
-  boolean isplayersprite;
 } vissprite_t;
 
 //

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -111,6 +111,7 @@ void R_InterpolateView (player_t *player)
     viewz = player->prev_viewz + FixedMul (frac, player->viewz - player->prev_viewz);
 
     viewangle = player->prev_viewangle + FixedMul (frac, R_SmoothPlaying_Get(player->mo->angle) - player->prev_viewangle) + viewangleoffset;
+    viewpitch = player->prev_viewpitch + FixedMul (frac, player->mo->pitch - player->prev_viewpitch) + viewpitchoffset;
   }
   else
   {
@@ -119,6 +120,7 @@ void R_InterpolateView (player_t *player)
     viewz = player->viewz;
 
     viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
+    viewpitch = R_SmoothPlaying_Get(player->mo->pitch) + viewpitchoffset;
   }
 
   if (!paused && movement_smooth)

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -50,10 +50,12 @@ extern int      centery;
 extern fixed_t  centerxfrac;
 extern fixed_t  centeryfrac;
 extern fixed_t  viewheightfrac; //e6y: for correct clipping of things
+extern fixed_t  freelookviewheight;
 extern fixed_t  projection;
 // proff 11/06/98: Added for high-res
 extern fixed_t  projectiony;
 extern int      validcount;
+extern fixed_t skyiscale;
 
 //
 // Rendering stats

--- a/src/r_plane.c
+++ b/src/r_plane.c
@@ -403,6 +403,12 @@ static void R_DoDrawPlane(visplane_t *pl)
             // allow old sky textures to be used.
 
             flip = l->special==272 ? 0u : ~0u;
+
+            if (skystretch)
+            {
+              int skyheight = textureheight[texture]>>FRACBITS;
+              dcvars.texturemid = (int64_t)dcvars.texturemid * skyheight / SKYSTRETCH_HEIGHT;
+            }
          }
          else
          {    // Normal Doom sky, only one allowed per level
@@ -421,8 +427,8 @@ static void R_DoDrawPlane(visplane_t *pl)
          dcvars.nextcolormap = dcvars.colormap; // for filtering -- POPE
 
          //dcvars.texturemid = skytexturemid;
-         dcvars.texheight = textureheight[skytexture]>>FRACBITS; // killough
-         dcvars.iscale = pspriteiscale;
+         dcvars.texheight = textureheight[texture]>>FRACBITS; // killough
+         dcvars.iscale = skyiscale;
 
          tex_patch = R_CacheTextureCompositePatchNum(texture);
 

--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -35,6 +35,9 @@
  *-----------------------------------------------------------------------------*/
 
 #include "r_sky.h"
+#include "r_main.h"
+#include "r_state.h"
+#include "doomstat.h"
 
 //
 // sky mapping
@@ -43,11 +46,76 @@ int skyflatnum;
 int skytexture;
 int skytexturemid;
 
+boolean r_stretchsky; // user option, named after ZDoom's
+int skystretch;
+
 //
 // R_InitSkyMap
 // Called whenever the view size changes.
 //
 void R_InitSkyMap (void)
 {
-  skytexturemid = 100*FRACUNIT;
+  if (!movement_mouselook)
+  {
+    skystretch = FALSE;
+    skytexturemid = 100*FRACUNIT;
+    if (viewwidth != 0)
+    {
+      skyiscale = (fixed_t)(((uint64_t)FRACUNIT * SCREENWIDTH * 200) / (viewwidth * SCREENHEIGHT));
+    }
+  }
+  else
+  {
+    int skyheight;
+
+    if (!textureheight)
+      return;
+
+    // There are various combinations for sky rendering depending on how tall the sky is:
+    //        h <  128: Unstretched and tiled, centered on horizon
+    // 128 <= h <  200: Can possibly be stretched. When unstretched, the baseline is
+    //                  28 rows below the horizon so that the top of the texture
+    //                  aligns with the top of the screen when looking straight ahead.
+    //                  When stretched, it is scaled to 228 pixels with the baseline
+    //                  in the same location as an unstretched 128-tall sky, so the top
+    //					of the texture aligns with the top of the screen when looking
+    //                  fully up.
+    //        h == 200: Unstretched, baseline is on horizon, and top is at the top of
+    //                  the screen when looking fully up.
+    //        h >  200: Unstretched, but the baseline is shifted down so that the top
+    //                  of the texture is at the top of the screen when looking fully up.
+
+    skyheight = textureheight[skytexture]>>FRACBITS;
+    skystretch = FALSE;
+    skytexturemid = 0;
+    if (skyheight >= 128 && skyheight < 200)
+    {
+      skystretch = (r_stretchsky && (skyheight >= 128));
+      skytexturemid = -28*FRACUNIT;
+    }
+    else if (skyheight > 200)
+    {
+      skytexturemid = (200 - skyheight) << FRACBITS;
+    }
+
+    if (viewwidth != 0 && viewheight != 0)
+    {
+      //skyiscale = 200 * FRACUNIT / freelookviewheight;
+      skyiscale = (fixed_t)(((uint64_t)FRACUNIT * SCREENWIDTH * 200) / (viewwidth * SCREENHEIGHT));
+      // line below is from zdoom, but it works incorrectly with prboom
+      // with widescreen resolutions (eg 1280x720) by some reasons
+      //skyiscale = (fixed_t)((int64_t)skyiscale * fieldofview / 2048);
+    }
+
+    if (skystretch)
+    {
+      skyiscale = (fixed_t)((int64_t)skyiscale * skyheight / SKYSTRETCH_HEIGHT);
+      skytexturemid = (int)((int64_t)skytexturemid * skyheight / SKYSTRETCH_HEIGHT);
+      I_Error("stretch!!! iscale:%d mid:%d", skyiscale,skytexturemid);
+    }
+    else
+    {
+      skytexturemid = 100*FRACUNIT;
+    }
+  }
 }

--- a/src/r_sky.c
+++ b/src/r_sky.c
@@ -47,7 +47,7 @@ int skytexture;
 int skytexturemid;
 
 boolean r_stretchsky; // user option, named after ZDoom's
-int skystretch;
+boolean skystretch;
 
 //
 // R_InitSkyMap

--- a/src/r_sky.h
+++ b/src/r_sky.h
@@ -45,6 +45,12 @@
 extern int skytexture;
 extern int skytexturemid;
 
+#define SKYSTRETCH_HEIGHT 228
+extern int skystretch;
+
+// user option to stretch the sky (see https://zdoom.org/wiki/Sky_stretching )
+extern boolean r_stretchsky;
+
 /* Called whenever the view size changes. */
 void R_InitSkyMap(void);
 

--- a/src/r_sky.h
+++ b/src/r_sky.h
@@ -45,11 +45,12 @@
 extern int skytexture;
 extern int skytexturemid;
 
+// Sky stretching (see https://zdoom.org/wiki/Sky_stretching )
 #define SKYSTRETCH_HEIGHT 228
-extern int skystretch;
+extern boolean r_stretchsky; // user option
+extern boolean skystretch;
 
-// user option to stretch the sky (see https://zdoom.org/wiki/Sky_stretching )
-extern boolean r_stretchsky;
+
 
 /* Called whenever the view size changes. */
 void R_InitSkyMap(void);

--- a/src/r_state.h
+++ b/src/r_state.h
@@ -95,10 +95,12 @@ extern fixed_t          viewx;
 extern fixed_t          viewy;
 extern fixed_t          viewz;
 extern angle_t          viewangle;
+extern angle_t          viewpitch;
 extern player_t         *viewplayer;
 extern angle_t          clipangle;
 extern int              viewangletox[FINEANGLES/2];
 extern angle_t          xtoviewangle[MAX_SCREENWIDTH+1];  // killough 2/8/98
+extern int              fieldofview;
 extern fixed_t          rw_distance;
 extern angle_t          rw_normalangle;
 

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -329,46 +329,46 @@ void R_DrawMaskedColumn(
       const rcolumn_t *nextcolumn
       )
 {
-   int     i;
-   int     topscreen;
-   int     bottomscreen;
-   fixed_t basetexturemid = dcvars->texturemid;
+  int     i;
+  int     topscreen;
+  int     bottomscreen;
+  fixed_t basetexturemid = dcvars->texturemid;
 
-   dcvars->texheight = patch->height; // killough 11/98
-   for (i=0; i<column->numPosts; i++) {
-      const rpost_t *post = &column->posts[i];
+  dcvars->texheight = patch->height; // killough 11/98
+  for (i=0; i<column->numPosts; i++) {
+    const rpost_t *post = &column->posts[i];
 
-      // calculate unclipped screen coordinates for post
-      topscreen = sprtopscreen + spryscale*post->topdelta;
-      bottomscreen = topscreen + spryscale*post->length;
+    // calculate unclipped screen coordinates for post
+    topscreen = sprtopscreen + spryscale*post->topdelta;
+    bottomscreen = topscreen + spryscale*post->length;
 
-      dcvars->yl = (topscreen+FRACUNIT-1)>>FRACBITS;
-      dcvars->yh = (bottomscreen-1)>>FRACBITS;
+    dcvars->yl = (topscreen+FRACUNIT-1)>>FRACBITS;
+    dcvars->yh = (bottomscreen-1)>>FRACBITS;
 
-      if (dcvars->yh >= mfloorclip[dcvars->x])
-         dcvars->yh = mfloorclip[dcvars->x]-1;
+    if (dcvars->yh >= mfloorclip[dcvars->x])
+      dcvars->yh = mfloorclip[dcvars->x]-1;
 
-      if (dcvars->yl <= mceilingclip[dcvars->x])
-         dcvars->yl = mceilingclip[dcvars->x]+1;
+    if (dcvars->yl <= mceilingclip[dcvars->x])
+      dcvars->yl = mceilingclip[dcvars->x]+1;
 
-      // killough 3/2/98, 3/27/98: Failsafe against overflow/crash:
-      if (dcvars->yl <= dcvars->yh && dcvars->yh < viewheight)
-      {
-         dcvars->source = column->pixels + post->topdelta;
-         dcvars->prevsource = prevcolumn->pixels + post->topdelta;
-         dcvars->nextsource = nextcolumn->pixels + post->topdelta;
+    // killough 3/2/98, 3/27/98: Failsafe against overflow/crash:
+    if (dcvars->yl <= dcvars->yh && dcvars->yh < viewheight)
+    {
+      dcvars->source = column->pixels + post->topdelta;
+      dcvars->prevsource = prevcolumn->pixels + post->topdelta;
+      dcvars->nextsource = nextcolumn->pixels + post->topdelta;
 
-         dcvars->texturemid = basetexturemid - (post->topdelta<<FRACBITS);
+      dcvars->texturemid = basetexturemid - (post->topdelta<<FRACBITS);
 
-         dcvars->edgeslope = post->slope;
-         // Drawn by either R_DrawColumn
-         //  or (SHADOW) R_DrawFuzzColumn.
-         dcvars->drawingmasked = 1; // POPE
-         colfunc (dcvars);
-         dcvars->drawingmasked = 0; // POPE
-      }
-   }
-   dcvars->texturemid = basetexturemid;
+      dcvars->edgeslope = post->slope;
+      // Drawn by either R_DrawColumn
+      //  or (SHADOW) R_DrawFuzzColumn.
+      dcvars->drawingmasked = 1; // POPE
+      colfunc (dcvars);
+      dcvars->drawingmasked = 0; // POPE
+    }
+  }
+  dcvars->texturemid = basetexturemid;
 }
 
 //
@@ -378,67 +378,74 @@ void R_DrawMaskedColumn(
 // CPhipps - new wad lump handling, *'s to const*'s
 static void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
 {
-   int      texturecolumn;
-   fixed_t  frac;
-   const rpatch_t *patch = R_CachePatchNum(vis->patch+firstspritelump);
-   R_DrawColumn_f colfunc;
-   draw_column_vars_t dcvars;
-   enum draw_filter_type_e filter;
-   enum draw_filter_type_e filterz;
+  int      texturecolumn;
+  fixed_t  frac;
+  const rpatch_t *patch = R_CachePatchNum(vis->patch+firstspritelump);
+  R_DrawColumn_f colfunc;
+  draw_column_vars_t dcvars;
+  enum draw_filter_type_e filter;
+  enum draw_filter_type_e filterz;
 
-   R_SetDefaultDrawColumnVars(&dcvars);
-   if (vis->mobjflags & MF_PLAYERSPRITE) {
-      dcvars.edgetype = drawvars.patch_edges;
-      filter = drawvars.filterpatch;
-      filterz = RDRAW_FILTER_POINT;
-   } else {
-      dcvars.edgetype = drawvars.sprite_edges;
-      filter = drawvars.filtersprite;
-      filterz = drawvars.filterz;
-   }
+  R_SetDefaultDrawColumnVars(&dcvars);
+  if (vis->mobjflags & MF_PLAYERSPRITE) {
+    dcvars.edgetype = drawvars.patch_edges;
+    filter = drawvars.filterpatch;
+    filterz = RDRAW_FILTER_POINT;
+  } else {
+    dcvars.edgetype = drawvars.sprite_edges;
+    filter = drawvars.filtersprite;
+    filterz = drawvars.filterz;
+  }
 
-   dcvars.colormap = vis->colormap;
-   dcvars.nextcolormap = dcvars.colormap; // for filtering -- POPE
+  dcvars.colormap = vis->colormap;
+  dcvars.nextcolormap = dcvars.colormap; // for filtering -- POPE
 
-   // killough 4/11/98: rearrange and handle translucent sprites
-   // mixed with translucent/non-translucenct 2s normals
+  // killough 4/11/98: rearrange and handle translucent sprites
+  // mixed with translucent/non-translucenct 2s normals
 
-   if (!dcvars.colormap)   // NULL colormap = shadow draw
-      colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_FUZZ, filter, filterz);    // killough 3/14/98
-   else
-      if (vis->mobjflags & MF_TRANSLATION)
-      {
-         colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_TRANSLATED, filter, filterz);
-         dcvars.translation = translationtables - 256 +
-            ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT-8) );
-      }
-      else
-         colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_STANDARD, filter, filterz); // killough 3/14/98, 4/11/98
+  if (!dcvars.colormap)   // NULL colormap = shadow draw
+    colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_FUZZ, filter, filterz);    // killough 3/14/98
+  else
+    if (vis->mobjflags & MF_TRANSLATION)
+    {
+      colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_TRANSLATED, filter, filterz);
+      dcvars.translation = translationtables - 256 +
+        ((vis->mobjflags & MF_TRANSLATION) >> (MF_TRANSSHIFT-8) );
+    }
+    else
+      colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_STANDARD, filter, filterz); // killough 3/14/98, 4/11/98
 
-   // proff 11/06/98: Changed for high-res
-   dcvars.iscale = FixedDiv (FRACUNIT, vis->scale);
-   dcvars.texturemid = vis->texturemid;
-   frac = vis->startfrac;
-   if (filter == RDRAW_FILTER_LINEAR)
-      frac -= (FRACUNIT>>1);
-   spryscale = vis->scale;
-   sprtopscreen = centeryfrac - FixedMul(dcvars.texturemid,spryscale);
+  // proff 11/06/98: Changed for high-res
+  dcvars.iscale = FixedDiv (FRACUNIT, vis->scale);
+  dcvars.texturemid = vis->texturemid;
+  frac = vis->startfrac;
+  if (filter == RDRAW_FILTER_LINEAR)
+    frac -= (FRACUNIT>>1);
+  spryscale = vis->scale;
+  sprtopscreen = centeryfrac - FixedMul(dcvars.texturemid,spryscale);
 
-   for (dcvars.x=vis->x1 ; dcvars.x<=vis->x2 ; dcvars.x++, frac += vis->xiscale)
-   {
-      texturecolumn = frac>>FRACBITS;
-      dcvars.texu = frac;
+  // make sure the player weapon is in a static position on the screen
+  if(vis->mobjflags & MF_PLAYERSPRITE)
+  {
+    dcvars.texturemid += FixedMul(((centery - viewheight/2)<<FRACBITS), dcvars.iscale);
+    sprtopscreen += (viewheight/2 - centery)<<FRACBITS;
+  }
 
-      R_DrawMaskedColumn(
-            patch,
-            colfunc,
-            &dcvars,
-            R_GetPatchColumnClamped(patch, texturecolumn),
-            R_GetPatchColumnClamped(patch, texturecolumn-1),
-            R_GetPatchColumnClamped(patch, texturecolumn+1)
-            );
-   }
-   R_UnlockPatchNum(vis->patch+firstspritelump); // cph - release lump
+  for (dcvars.x=vis->x1 ; dcvars.x<=vis->x2 ; dcvars.x++, frac += vis->xiscale)
+  {
+    texturecolumn = frac>>FRACBITS;
+    dcvars.texu = frac;
+
+    R_DrawMaskedColumn(
+      patch,
+      colfunc,
+      &dcvars,
+      R_GetPatchColumnClamped(patch, texturecolumn),
+      R_GetPatchColumnClamped(patch, texturecolumn-1),
+      R_GetPatchColumnClamped(patch, texturecolumn+1)
+    );
+  }
+  R_UnlockPatchNum(vis->patch+firstspritelump); // cph - release lump
 }
 
 //
@@ -990,6 +997,6 @@ void R_DrawMasked(void)
 
    // draw the psprites on top of everything
    //  but does not draw on side views
-   if (!viewangleoffset)
+   if (!viewangleoffset && !viewpitchoffset)
       R_DrawPlayerSprites ();
 }

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -387,7 +387,7 @@ static void R_DrawVisSprite(vissprite_t *vis, int x1, int x2)
    enum draw_filter_type_e filterz;
 
    R_SetDefaultDrawColumnVars(&dcvars);
-   if (vis->isplayersprite) {
+   if (vis->mobjflags & MF_PLAYERSPRITE) {
       dcvars.edgetype = drawvars.patch_edges;
       filter = drawvars.filterpatch;
       filterz = RDRAW_FILTER_POINT;
@@ -667,8 +667,6 @@ static void R_DrawPSprite (pspdef_t *psp, int lightlevel)
    int           width;
    fixed_t       topoffset;
 
-   avis.isplayersprite = TRUE;
-
    // decide which patch to use
 
    sprdef = &sprites[psp->state->sprite];
@@ -701,7 +699,7 @@ static void R_DrawPSprite (pspdef_t *psp, int lightlevel)
 
    // store information in a vissprite
    vis = &avis;
-   vis->mobjflags = 0;
+   vis->mobjflags = MF_PLAYERSPRITE;
    // killough 12/98: fix psprite positioning problem
    vis->texturemid = (BASEYCENTER<<FRACBITS) /* +  FRACUNIT/2 */ -
       (psp->sy-topoffset);


### PR DESCRIPTION
Backported from PrBoom-plus.
It uses the same logic as Heretic, the (optional) sky stretching logic is [similar to ZDoom software rendering](https://zdoom.org/wiki/Sky_stretching).

It's disabled by default, settings for it are added in the in-game options.
The default maximum angle of 36° prevents sky tiling (when sky stretching is enabled) or too much distortion, but it can be increased up to 80° (it starts getting sickening with more).