### PR TITLE
Dehardcode some monster behavior and expand dehacked

### DIFF
--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1036,7 +1036,7 @@ typedef struct
 // killough 8/9/98: make DEH_BLOCKMAX self-adjusting
 #define DEH_BLOCKMAX (sizeof deh_blocks/sizeof*deh_blocks)  // size of array
 #define DEH_MAXKEYLEN 32 // as much of any key as we'll look at
-#define DEH_MOBJINFOMAX 24 // number of ints in the mobjinfo_t structure (!)
+#define DEH_MOBJINFOMAX 25 // number of ints in the mobjinfo_t structure (!)
 
 // Put all the block header values, and the function to be called when that
 // one is encountered, in this array:
@@ -1092,6 +1092,7 @@ static const char *deh_mobjinfo[DEH_MOBJINFOMAX] =
   "Death frame",         // .deathstate
   "Exploding frame",     // .xdeathstate
   "Death sound",         // .deathsound
+  "Dropped item",        // .droppeditem
   "Speed",               // .speed
   "Width",               // .radius
   "Height",              // .height
@@ -1695,15 +1696,16 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint64_t value) {
     case 12: mi->deathstate = (int)value; return;
     case 13: mi->xdeathstate = (int)value; return;
     case 14: mi->deathsound = (int)value; return;
-    case 15: mi->speed = (int)value; return;
-    case 16: mi->radius = (int)value; return;
-    case 17: mi->height = (int)value; return;
-    case 18: mi->mass = (int)value; return;
-    case 19: mi->damage = (int)value; return;
-    case 20: mi->activesound = (int)value; return;
-    case 21: mi->flags = value; return;
-    case 22: return; // "Bits2", unused
-    case 23: mi->raisestate = (int)value; return;
+    case 15: mi->droppeditem = (int)value; return;
+    case 16: mi->speed = (int)value; return;
+    case 17: mi->radius = (int)value; return;
+    case 18: mi->height = (int)value; return;
+    case 19: mi->mass = (int)value; return;
+    case 20: mi->damage = (int)value; return;
+    case 21: mi->activesound = (int)value; return;
+    case 22: mi->flags = value; return;
+    case 23: return; // "Bits2", unused
+    case 24: mi->raisestate = (int)value; return;
     default: return;
   }
 }

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1172,6 +1172,8 @@ static const struct deh_mobjflags_s deh_mobjflags[] = {
   {"FULLVOLDEATH", MF_FULLVOLDEATH},    // plays its death sound at full volume
   {"NORADIUSDMG",  MF_NORADIUSDMG},  // radius (explosive) damage doesnt harm it
   {"QUICKTORETALIATE", MF_QUICKTORETALIATE}, // immediately switch target if attacked
+  {"ISMONSTER",    MF_ISMONSTER},    // for all monsters, even those that don't count in kill%
+  {"DONTFALL",     MF_DONTFALL},     // doesn't fall down after being killed (for the Lost Soul)
 };
 
 // STATE - Dehacked block name = "Frame" and "Pointer"
@@ -1832,6 +1834,14 @@ static void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
                 fprintf(fpout, "Could not find bit mnemonic %s\n", strval);
               }
             }
+
+            // the MF_COUNTKILL flag used to be indicative of the Mobj being a
+            // monster, but this is no longer true after the logic for monsters_infight
+            // that don't count towards limit was dehardcoded.
+            // Let's make sure that any actor that has MF_COUNTKILL is considered
+            // a monster, avoid incompatibility with older DEH files
+            if (value & MF_COUNTKILL)
+              value |= MF_ISMONSTER;
 
             // Don't worry about conversion -- simply print values
             if (fpout) {

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1167,6 +1167,9 @@ static const struct deh_mobjflags_s deh_mobjflags[] = {
   {"FRIEND",       MF_FRIEND},       // a friend of the player(s) (MBF)
 
   {"MISSILEMORE",  MF_MISSILEMORE},  // more often missile attacks from far away (like Cyber)
+  {"FULLVOLSIGHT", MF_FULLVOLSIGHT}, // plays its alert sound at full volume
+  {"FULLVOLDEATH", MF_FULLVOLDEATH},    // plays its death sound at full volume
+  {"NORADIUSDMG",  MF_NORADIUSDMG},  // radius (explosive) damage doesnt harm it
 };
 
 // STATE - Dehacked block name = "Frame" and "Pointer"

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1166,10 +1166,12 @@ static const struct deh_mobjflags_s deh_mobjflags[] = {
   {"BOUNCES",      MF_BOUNCES},      // bounces off floors, ceilings and maybe walls (MBF)
   {"FRIEND",       MF_FRIEND},       // a friend of the player(s) (MBF)
 
+  {"NOTARGET",     MF_NOTARGET},     // won't be targetted even if it hurts someone else
   {"MISSILEMORE",  MF_MISSILEMORE},  // more often missile attacks from far away (like Cyber)
   {"FULLVOLSIGHT", MF_FULLVOLSIGHT}, // plays its alert sound at full volume
   {"FULLVOLDEATH", MF_FULLVOLDEATH},    // plays its death sound at full volume
   {"NORADIUSDMG",  MF_NORADIUSDMG},  // radius (explosive) damage doesnt harm it
+  {"QUICKTORETALIATE", MF_QUICKTORETALIATE}, // immediately switch target if attacked
 };
 
 // STATE - Dehacked block name = "Frame" and "Pointer"

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1036,7 +1036,7 @@ typedef struct
 // killough 8/9/98: make DEH_BLOCKMAX self-adjusting
 #define DEH_BLOCKMAX (sizeof deh_blocks/sizeof*deh_blocks)  // size of array
 #define DEH_MAXKEYLEN 32 // as much of any key as we'll look at
-#define DEH_MOBJINFOMAX 25 // number of ints in the mobjinfo_t structure (!)
+#define DEH_MOBJINFOMAX 28 // number of ints in the mobjinfo_t structure (!)
 
 // Put all the block header values, and the function to be called when that
 // one is encountered, in this array:
@@ -1102,6 +1102,9 @@ static const char *deh_mobjinfo[DEH_MOBJINFOMAX] =
   "Bits",                // .flags
   "Bits2",               // .flags
   "Respawn frame"        // .raisestate
+  "Melee threshold "     // .meleethreshold
+  "Max target range"     // .maxattackrange
+  "Min missile chance"   // .minmissilechance
 };
 
 // Strings that are used to indicate flags ("Bits" in mobjinfo)
@@ -1162,6 +1165,8 @@ static const struct deh_mobjflags_s deh_mobjflags[] = {
   {"TOUCHY",       MF_TOUCHY},       // dies on contact with solid objects (MBF)
   {"BOUNCES",      MF_BOUNCES},      // bounces off floors, ceilings and maybe walls (MBF)
   {"FRIEND",       MF_FRIEND},       // a friend of the player(s) (MBF)
+
+  {"MISSILEMORE",  MF_MISSILEMORE},  // more often missile attacks from far away (like Cyber)
 };
 
 // STATE - Dehacked block name = "Frame" and "Pointer"
@@ -1706,6 +1711,9 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint64_t value) {
     case 22: mi->flags = value; return;
     case 23: return; // "Bits2", unused
     case 24: mi->raisestate = (int)value; return;
+    case 25: mi->meleethreshold = (int)value; return;
+    case 26: mi->maxattackrange = (int)value; return;
+    case 27: mi->minmissilechance = (int)value; return;
     default: return;
   }
 }

--- a/src/info.c
+++ b/src/info.c
@@ -1329,7 +1329,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     500,    // mass
     0,    // damage
     sfx_vilact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_NOTARGET|MF_QUICKTORETALIATE,   // flags
     S_NULL,   // raisestateraisestate
     0,     // meleethreshold
     14*64, // maxattackrange

--- a/src/info.c
+++ b/src/info.c
@@ -1269,7 +1269,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     0,    // damage
     sfx_posact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_POSS_RAISE1,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1299,7 +1299,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     0,    // damage
     sfx_posact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_SPOS_RAISE1,   // raisestateraisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1329,7 +1329,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     500,    // mass
     0,    // damage
     sfx_vilact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_NOTARGET|MF_QUICKTORETALIATE,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_NOTARGET|MF_QUICKTORETALIATE,   // flags
     S_NULL,   // raisestateraisestate
     0,     // meleethreshold
     14*64, // maxattackrange
@@ -1389,7 +1389,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     500,    // mass
     0,    // damage
     sfx_skeact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_SKEL_RAISE1,  // raisestateraisestate
     196,  // meleethreshold
     0,    // maxattackrange
@@ -1479,7 +1479,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_posact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_FATT_RAISE1,  // raisestateraisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1539,7 +1539,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     0,    // damage
     sfx_posact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_CPOS_RAISE1,  // raisestateraisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1569,7 +1569,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     0,    // damage
     sfx_bgact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL, // killough |MF_TRANSLUCENT,   // flags     // phares
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL, // killough |MF_TRANSLUCENT,   // flags     // phares
     S_TROO_RAISE1,  // raisestateraisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1599,7 +1599,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     400,    // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_SARG_RAISE1,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1629,7 +1629,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     400,    // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_SHADOW|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_SHADOW|MF_COUNTKILL,   // flags
     S_SARG_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1659,7 +1659,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     400,    // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_COUNTKILL,   // flags
     S_HEAD_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1689,7 +1689,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_BOSS_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1749,7 +1749,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_BOS2_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1779,7 +1779,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     50,   // mass
     3,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_MISSILEMORE, // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_MISSILEMORE, // flags
     S_NULL,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1809,7 +1809,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE|MF_FULLVOLSIGHT|MF_FULLVOLDEATH|MF_NORADIUSDMG,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE|MF_FULLVOLSIGHT|MF_FULLVOLDEATH|MF_NORADIUSDMG,   // flags
     S_NULL,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1839,7 +1839,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     600,    // mass
     0,    // damage
     sfx_bspact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_BSPI_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1869,7 +1869,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE|MF_FULLVOLSIGHT|MF_FULLVOLDEATH|MF_NORADIUSDMG,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE|MF_FULLVOLSIGHT|MF_FULLVOLDEATH|MF_NORADIUSDMG,   // flags
     S_NULL,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1899,7 +1899,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     400,    // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_COUNTKILL,   // flags
     S_PAIN_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1929,7 +1929,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     100,    // mass
     0,    // damage
     sfx_posact,   // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+    MF_ISMONSTER|MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
     S_SSWV_RAISE1,  // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1959,7 +1959,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     10000000,   // mass
     0,    // damage
     sfx_None,   // activesound
-    MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY|MF_SHOOTABLE|MF_COUNTKILL,    // flags
+    MF_ISMONSTER|MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY|MF_SHOOTABLE|MF_COUNTKILL,    // flags
     S_NULL,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange

--- a/src/info.c
+++ b/src/info.c
@@ -1809,7 +1809,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE,   // flags
+    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE|MF_FULLVOLSIGHT|MF_FULLVOLDEATH|MF_NORADIUSDMG,   // flags
     S_NULL,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange
@@ -1869,7 +1869,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE,   // flags
+    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE|MF_FULLVOLSIGHT|MF_FULLVOLDEATH|MF_NORADIUSDMG,   // flags
     S_NULL,   // raisestate
     0,    // meleethreshold
     0,    // maxattackrange

--- a/src/info.c
+++ b/src/info.c
@@ -1232,6 +1232,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_PLAY_DIE1,    // deathstate
     S_PLAY_XDIE1,   // xdeathstate
     sfx_pldeth,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1258,6 +1259,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_POSS_DIE1,    // deathstate
     S_POSS_XDIE1,   // xdeathstate
     sfx_podth1,   // deathsound
+    MT_CLIP,      // droppeditem
     8,    // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1284,6 +1286,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SPOS_DIE1,    // deathstate
     S_SPOS_XDIE1,   // xdeathstate
     sfx_podth2,   // deathsound
+    MT_SHOTGUN,   // droppeditem
     8,    // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1310,6 +1313,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_VILE_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_vildth,   // deathsound
+    MT_NULL,      // droppeditem
     15,   // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1336,6 +1340,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -1362,6 +1367,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SKEL_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_skedth,   // deathsound
+    MT_NULL,      // droppeditem
     10,   // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1388,6 +1394,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_TRACEEXP1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_barexp,   // deathsound
+    MT_NULL,      // droppeditem
     10*FRACUNIT,    // speed
     11*FRACUNIT,    // radius
     8*FRACUNIT,   // height
@@ -1414,6 +1421,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -1440,6 +1448,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_FATT_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_mandth,   // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     48*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -1466,6 +1475,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_FATSHOTX1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     20*FRACUNIT,    // speed
     6*FRACUNIT,   // radius
     8*FRACUNIT,   // height
@@ -1492,6 +1502,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_CPOS_DIE1,    // deathstate
     S_CPOS_XDIE1,   // xdeathstate
     sfx_podth2,   // deathsound
+    MT_CHAINGUN,  // droppeditem
     8,    // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1518,6 +1529,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_TROO_DIE1,    // deathstate
     S_TROO_XDIE1,   // xdeathstate
     sfx_bgdth1,   // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1544,6 +1556,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SARG_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_sgtdth,   // deathsound
+    MT_NULL,      // droppeditem
     10,   // speed
     30*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1570,6 +1583,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SARG_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_sgtdth,   // deathsound
+    MT_NULL,      // droppeditem
     10,   // speed
     30*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1596,6 +1610,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_HEAD_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_cacdth,   // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     31*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1622,6 +1637,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BOSS_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_brsdth,   // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     24*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -1648,6 +1664,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BRBALLX1,   // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     15*FRACUNIT,   // speed
     6*FRACUNIT,   // radius
     8*FRACUNIT,   // height
@@ -1674,6 +1691,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BOS2_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_kntdth,   // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     24*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -1700,6 +1718,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SKULL_DIE1,   // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     16*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1726,6 +1745,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SPID_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_spidth,   // deathsound
+    MT_NULL,      // droppeditem
     12,   // speed
     128*FRACUNIT,   // radius
     100*FRACUNIT,   // height
@@ -1752,6 +1772,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BSPI_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_bspdth,   // deathsound
+    MT_NULL,      // droppeditem
     12,   // speed
     64*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -1778,6 +1799,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_CYBER_DIE1,   // deathstate
     S_NULL,   // xdeathstate
     sfx_cybdth,   // deathsound
+    MT_NULL,      // droppeditem
     16,   // speed
     40*FRACUNIT,    // radius
     110*FRACUNIT,   // height
@@ -1804,6 +1826,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_PAIN_DIE1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_pedth,    // deathsound
+    MT_NULL,      // droppeditem
     8,    // speed
     31*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1830,6 +1853,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_SSWV_DIE1,    // deathstate
     S_SSWV_XDIE1,   // xdeathstate
     sfx_ssdth,    // deathsound
+    MT_CLIP,      // droppeditem
     8,    // speed
     20*FRACUNIT,    // radius
     56*FRACUNIT,    // height
@@ -1856,6 +1880,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_COMMKEEN,   // deathstate
     S_NULL,   // xdeathstate
     sfx_keendt,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     72*FRACUNIT,    // height
@@ -1882,6 +1907,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BRAIN_DIE1,   // deathstate
     S_NULL,   // xdeathstate
     sfx_bosdth,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -1908,6 +1934,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     32*FRACUNIT,    // height
@@ -1934,6 +1961,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     32*FRACUNIT,    // height
@@ -1960,6 +1988,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     10*FRACUNIT,    // speed
     6*FRACUNIT,   // radius
     32*FRACUNIT,    // height
@@ -1986,6 +2015,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2012,6 +2042,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BEXP,   // deathstate
     S_NULL,   // xdeathstate
     sfx_barexp,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     10*FRACUNIT,    // radius
     42*FRACUNIT,    // height
@@ -2038,6 +2069,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_TBALLX1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     10*FRACUNIT,    // speed
     6*FRACUNIT,   // radius
     8*FRACUNIT,   // height
@@ -2064,6 +2096,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_RBALLX1,    // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     10*FRACUNIT,    // speed
     6*FRACUNIT,   // radius
     8*FRACUNIT,   // height
@@ -2090,6 +2123,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_EXPLODE1,   // deathstate
     S_NULL,   // xdeathstate
     sfx_barexp,   // deathsound
+    MT_NULL,      // droppeditem
     20*FRACUNIT,    // speed
     11*FRACUNIT,    // radius
     8*FRACUNIT,   // height
@@ -2116,6 +2150,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_PLASEXP,    // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     25*FRACUNIT,    // speed
     13*FRACUNIT,    // radius
     8*FRACUNIT,   // height
@@ -2142,6 +2177,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_BFGLAND,    // deathstate
     S_NULL,   // xdeathstate
     sfx_rxplod,   // deathsound
+    MT_NULL,      // droppeditem
     25*FRACUNIT,    // speed
     13*FRACUNIT,    // radius
     8*FRACUNIT,   // height
@@ -2168,6 +2204,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_ARACH_PLEX,   // deathstate
     S_NULL,   // xdeathstate
     sfx_firxpl,   // deathsound
+    MT_NULL,      // droppeditem
     25*FRACUNIT,    // speed
     13*FRACUNIT,    // radius
     8*FRACUNIT,   // height
@@ -2194,6 +2231,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2220,6 +2258,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2246,6 +2285,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2272,6 +2312,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2298,6 +2339,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2324,6 +2366,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2350,6 +2393,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2376,6 +2420,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2402,6 +2447,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2428,6 +2474,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2454,6 +2501,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2480,6 +2528,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2506,6 +2555,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2532,6 +2582,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2558,6 +2609,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2584,6 +2636,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2610,6 +2663,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2636,6 +2690,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2662,6 +2717,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2688,6 +2744,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2714,6 +2771,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2740,6 +2798,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2766,6 +2825,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2792,6 +2852,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2818,6 +2879,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2844,6 +2906,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2870,6 +2933,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2896,6 +2960,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2922,6 +2987,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2948,6 +3014,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -2974,6 +3041,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3000,6 +3068,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3026,6 +3095,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3052,6 +3122,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3078,6 +3149,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3104,6 +3176,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3130,6 +3203,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3156,6 +3230,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3182,6 +3257,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3208,6 +3284,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3234,6 +3311,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3260,6 +3338,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3286,6 +3365,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3312,6 +3392,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3338,6 +3419,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3364,6 +3446,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3390,6 +3473,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3416,6 +3500,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3442,6 +3527,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3468,6 +3554,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3494,6 +3581,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3520,6 +3608,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3546,6 +3635,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3572,6 +3662,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3598,6 +3689,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3624,6 +3716,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3650,6 +3743,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3676,6 +3770,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3702,6 +3797,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3728,6 +3824,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3754,6 +3851,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3780,6 +3878,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3806,6 +3905,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3832,6 +3932,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -3858,6 +3959,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     68*FRACUNIT,    // height
@@ -3884,6 +3986,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     84*FRACUNIT,    // height
@@ -3910,6 +4013,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     84*FRACUNIT,    // height
@@ -3936,6 +4040,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     68*FRACUNIT,    // height
@@ -3962,6 +4067,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     52*FRACUNIT,    // height
@@ -3988,6 +4094,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     84*FRACUNIT,    // height
@@ -4014,6 +4121,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     68*FRACUNIT,    // height
@@ -4040,6 +4148,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     52*FRACUNIT,    // height
@@ -4066,6 +4175,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     52*FRACUNIT,    // height
@@ -4092,6 +4202,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     68*FRACUNIT,    // height
@@ -4118,6 +4229,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4144,6 +4256,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4170,6 +4283,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4196,6 +4310,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4222,6 +4337,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4248,6 +4364,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4274,6 +4391,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4300,6 +4418,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4326,6 +4445,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4352,6 +4472,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4378,6 +4499,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4404,6 +4526,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4430,6 +4553,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4456,6 +4580,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4482,6 +4607,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4508,6 +4634,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     32*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4534,6 +4661,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4560,6 +4688,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     88*FRACUNIT,    // height
@@ -4586,6 +4715,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     88*FRACUNIT,    // height
@@ -4612,6 +4742,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -4638,6 +4769,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -4664,6 +4796,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -4690,6 +4823,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     16*FRACUNIT,    // radius
     64*FRACUNIT,    // height
@@ -4716,6 +4850,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4742,6 +4877,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4768,6 +4904,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,   // deathstate
     S_NULL,   // xdeathstate
     sfx_None,   // deathsound
+    MT_NULL,      // droppeditem
     0,    // speed
     20*FRACUNIT,    // radius
     16*FRACUNIT,    // height
@@ -4795,6 +4932,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,         // deathstate
     S_NULL,         // xdeathstate
     sfx_None,       // deathsound
+    MT_NULL,        // droppeditem
     0,              // speed
     8,              // radius
     8,              // height
@@ -4822,6 +4960,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     S_NULL,         // deathstate
     S_NULL,         // xdeathstate
     sfx_None,       // deathsound
+    MT_NULL,        // droppeditem
     0,              // speed
     8,              // radius
     8,              // height

--- a/src/info.c
+++ b/src/info.c
@@ -1240,7 +1240,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_DROPOFF|MF_PICKUP|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,    // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_POSSESSED
@@ -1267,7 +1270,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_posact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_POSS_RAISE1   // raisestate
+    S_POSS_RAISE1,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    0,    // minmissilechance
   },
 
   {   // MT_SHOTGUY
@@ -1294,7 +1300,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_posact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_SPOS_RAISE1   // raisestate
+    S_SPOS_RAISE1,   // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_VILE
@@ -1321,7 +1330,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_vilact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestateraisestate
+    0,     // meleethreshold
+    14*64, // maxattackrange
+    200,   // minmissilechance
   },
 
   {   // MT_FIRE
@@ -1348,7 +1360,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY|MF_TRANSLUCENT,   // flags  // killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_UNDEAD
@@ -1375,7 +1390,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_skeact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_SKEL_RAISE1   // raisestate
+    S_SKEL_RAISE1,  // raisestateraisestate
+    196,  // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_TRACER
@@ -1402,7 +1420,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     10,   // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SMOKE
@@ -1429,7 +1450,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY|MF_TRANSLUCENT,   // flags             // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_FATSO
@@ -1456,7 +1480,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_posact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_FATT_RAISE1   // raisestate
+    S_FATT_RAISE1,  // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_FATSHOT
@@ -1483,7 +1510,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     8,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT,   // flags \\ killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_CHAINGUY
@@ -1510,7 +1540,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_posact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_CPOS_RAISE1   // raisestate
+    S_CPOS_RAISE1,  // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_TROOP
@@ -1537,7 +1570,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_bgact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL, // killough |MF_TRANSLUCENT,   // flags     // phares
-    S_TROO_RAISE1   // raisestate
+    S_TROO_RAISE1,  // raisestateraisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SERGEANT
@@ -1564,7 +1600,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_dmact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_SARG_RAISE1   // raisestate
+    S_SARG_RAISE1,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SHADOWS
@@ -1591,7 +1630,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_dmact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_SHADOW|MF_COUNTKILL,   // flags
-    S_SARG_RAISE1   // raisestate
+    S_SARG_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_HEAD
@@ -1618,7 +1660,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_dmact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_COUNTKILL,   // flags
-    S_HEAD_RAISE1   // raisestate
+    S_HEAD_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BRUISER
@@ -1645,7 +1690,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_dmact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_BOSS_RAISE1   // raisestate
+    S_BOSS_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BRUISERSHOT
@@ -1672,7 +1720,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     8,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT,   // flags  killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_KNIGHT
@@ -1699,7 +1750,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_dmact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_BOS2_RAISE1   // raisestate
+    S_BOS2_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SKULL
@@ -1725,8 +1779,11 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     50,   // mass
     3,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_MISSILEMORE, // flags
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SPIDER
@@ -1752,8 +1809,11 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_NULL    // raisestate
+    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE,   // flags
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BABY
@@ -1780,7 +1840,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_bspact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_BSPI_RAISE1   // raisestate
+    S_BSPI_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_CYBORG
@@ -1806,8 +1869,11 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     1000,   // mass
     0,    // damage
     sfx_dmact,    // activesound
-    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_NULL    // raisestate
+    MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL|MF_MISSILEMORE,   // flags
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    160,  // minmissilechance
   },
 
   {   // MT_PAIN
@@ -1834,7 +1900,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_dmact,    // activesound
     MF_SOLID|MF_SHOOTABLE|MF_FLOAT|MF_NOGRAVITY|MF_COUNTKILL,   // flags
-    S_PAIN_RAISE1   // raisestate
+    S_PAIN_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_WOLFSS
@@ -1861,7 +1930,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_posact,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
-    S_SSWV_RAISE1   // raisestate
+    S_SSWV_RAISE1,  // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_KEEN
@@ -1888,7 +1960,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY|MF_SHOOTABLE|MF_COUNTKILL,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BOSSBRAIN
@@ -1915,7 +1990,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SHOOTABLE,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BOSSSPIT
@@ -1942,7 +2020,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOSECTOR,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BOSSTARGET
@@ -1969,7 +2050,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOSECTOR,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SPAWNSHOT
@@ -1996,7 +2080,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     3,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_NOCLIP,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SPAWNFIRE
@@ -2023,7 +2110,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY|MF_TRANSLUCENT,   // flags             // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BARREL
@@ -2050,7 +2140,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SHOOTABLE|MF_NOBLOOD,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_TROOPSHOT
@@ -2077,7 +2170,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     3,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_HEADSHOT
@@ -2104,7 +2200,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     5,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_ROCKET
@@ -2131,7 +2230,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     20,   // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_PLASMA
@@ -2158,7 +2260,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     5,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BFG
@@ -2185,7 +2290,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     100,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_ARACHPLAZ
@@ -2212,7 +2320,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     5,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_PUFF
@@ -2239,7 +2350,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_BLOOD
@@ -2266,7 +2380,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_TFOG
@@ -2293,7 +2410,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_IFOG
@@ -2320,7 +2440,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY|MF_TRANSLUCENT, // flags // phares
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_TELEPORTMAN
@@ -2347,7 +2470,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOSECTOR,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_EXTRABFG
@@ -2374,7 +2500,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC0
@@ -2401,7 +2530,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC1
@@ -2428,7 +2560,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC2
@@ -2455,7 +2590,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC3
@@ -2482,7 +2620,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC4
@@ -2509,7 +2650,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC5
@@ -2536,7 +2680,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC6
@@ -2563,7 +2710,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC7
@@ -2590,7 +2740,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC8
@@ -2617,7 +2770,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC9
@@ -2644,7 +2800,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_NOTDMATCH,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC10
@@ -2671,7 +2830,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC11
@@ -2698,7 +2860,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC12
@@ -2725,7 +2890,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM|MF_TRANSLUCENT,    // flags   // killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_INV
@@ -2752,7 +2920,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM|MF_TRANSLUCENT,    // flags // killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC13
@@ -2779,7 +2950,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_INS
@@ -2806,7 +2980,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM|MF_TRANSLUCENT,    // flags // killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC14
@@ -2833,7 +3010,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC15
@@ -2860,7 +3040,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC16
@@ -2887,7 +3070,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MEGA
@@ -2914,7 +3100,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL|MF_COUNTITEM|MF_TRANSLUCENT,    // flags // killough 2/21/98
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_CLIP
@@ -2941,7 +3130,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC17
@@ -2968,7 +3160,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC18
@@ -2995,7 +3190,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC19
@@ -3022,7 +3220,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC20
@@ -3049,7 +3250,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC21
@@ -3076,7 +3280,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC22
@@ -3103,7 +3310,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC23
@@ -3130,7 +3340,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC24
@@ -3157,7 +3370,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC25
@@ -3184,7 +3400,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_CHAINGUN
@@ -3211,7 +3430,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC26
@@ -3238,7 +3460,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC27
@@ -3265,7 +3490,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC28
@@ -3292,7 +3520,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SHOTGUN
@@ -3319,7 +3550,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_SUPERSHOTGUN
@@ -3346,7 +3580,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPECIAL,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC29
@@ -3373,7 +3610,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC30
@@ -3400,7 +3640,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC31
@@ -3427,7 +3670,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC32
@@ -3454,7 +3700,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC33
@@ -3481,7 +3730,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC34
@@ -3508,7 +3760,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC35
@@ -3535,7 +3790,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC36
@@ -3562,7 +3820,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC37
@@ -3589,7 +3850,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC38
@@ -3616,7 +3880,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC39
@@ -3643,7 +3910,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC40
@@ -3670,7 +3940,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC41
@@ -3697,7 +3970,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC42
@@ -3724,7 +4000,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC43
@@ -3751,7 +4030,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC44
@@ -3778,7 +4060,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC45
@@ -3805,7 +4090,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC46
@@ -3832,7 +4120,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC47
@@ -3859,7 +4150,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC48
@@ -3886,7 +4180,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC49
@@ -3913,7 +4210,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC50
@@ -3940,7 +4240,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC51
@@ -3967,7 +4270,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC52
@@ -3994,7 +4300,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC53
@@ -4021,7 +4330,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC54
@@ -4048,7 +4360,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC55
@@ -4075,7 +4390,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC56
@@ -4102,7 +4420,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPAWNCEILING|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC57
@@ -4129,7 +4450,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPAWNCEILING|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC58
@@ -4156,7 +4480,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPAWNCEILING|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC59
@@ -4183,7 +4510,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPAWNCEILING|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC60
@@ -4210,7 +4540,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SPAWNCEILING|MF_NOGRAVITY,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC61
@@ -4237,7 +4570,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC62
@@ -4264,7 +4600,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC63
@@ -4291,7 +4630,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC64
@@ -4318,7 +4660,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC65
@@ -4345,7 +4690,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC66
@@ -4372,7 +4720,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC67
@@ -4399,7 +4750,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC68
@@ -4426,7 +4780,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC69
@@ -4453,7 +4810,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC70
@@ -4480,7 +4840,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC71
@@ -4507,7 +4870,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     0,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC72
@@ -4534,7 +4900,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC73
@@ -4561,7 +4930,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC74
@@ -4588,7 +4960,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC75
@@ -4615,7 +4990,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC76
@@ -4642,7 +5020,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC77
@@ -4669,7 +5050,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID,   // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC78
@@ -4696,7 +5080,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC79
@@ -4723,7 +5110,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC80
@@ -4750,7 +5140,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC81
@@ -4777,7 +5170,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC82
@@ -4804,7 +5200,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC83
@@ -4831,7 +5230,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_SOLID|MF_SPAWNCEILING|MF_NOGRAVITY,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC84
@@ -4858,7 +5260,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC85
@@ -4883,9 +5288,11 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     16*FRACUNIT,    // height
     100,    // mass
     0,    // damage
-    sfx_None,   // activesound
     MF_NOBLOCKMAP,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   {   // MT_MISC86
@@ -4912,7 +5319,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,    // damage
     sfx_None,   // activesound
     MF_NOBLOCKMAP,    // flags
-    S_NULL    // raisestate
+    S_NULL,   // raisestate
+    0,    // meleethreshold
+    0,    // maxattackrange
+    200,  // minmissilechance
   },
 
   // For use with wind and current effects
@@ -4940,7 +5350,10 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,              // damage
     sfx_None,       // activesound
     MF_NOBLOCKMAP,  // flags
-    S_NULL          // raisestate
+    S_NULL,         // raisestate
+    0,               // meleethreshold
+    0,              // maxattackrange
+    200,            // minmissilechance
   },
 
   // For use with wind and current effects
@@ -4968,6 +5381,9 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
     0,              // damage
     sfx_None,       // activesound
     MF_NOBLOCKMAP,  // flags
-    S_NULL          // raisestate
+    S_NULL,         // raisestate
+    0,               // meleethreshold
+    0,              // maxattackrange
+    200,            // minmissilechance
   },
 };

--- a/src/info.h
+++ b/src/info.h
@@ -1426,7 +1426,8 @@ typedef enum {
   MT_STEALTHSHOTGUY,
   MT_STEALTHZOMBIE,
 
-  NUMMOBJTYPES  // Counter of how many there are
+  NUMMOBJTYPES,  // Counter of how many there are
+  MT_NULL = -1
 } mobjtype_t;
 
 /********************************************************************
@@ -1467,6 +1468,7 @@ typedef struct
   int deathsound;   /* The death sound.  See also A_Scream() in
            p_enemy.c for some tweaking that goes on
            for certain monsters */
+  mobjtype_t droppeditem; /* Mobj to drop after death */
   int speed;        /* How fast it moves.  Too fast and it can miss
            collision logic. */
   int radius;       /* An often incorrect radius */

--- a/src/info.h
+++ b/src/info.h
@@ -1484,6 +1484,9 @@ typedef struct
   int raisestate;   /* The first state for an Archvile or respawn
            resurrection.  Zero means it won't come
            back to life. */
+  int meleethreshold; /* Distance to switch from missile to melee attack */
+  int maxattackrange; /* Maximum distance range to start shooting */
+  int minmissilechance; /* Minimum chance for firing a missile */
 } mobjinfo_t;
 
 /* See p_mobj_h for addition more technical info */

--- a/src/m_cheat.c
+++ b/src/m_cheat.c
@@ -532,8 +532,7 @@ static void cheat_massacre()    // jff 2/01/98 kill all monsters
     while ((currentthinker = P_NextThinker(currentthinker,th_all)) != NULL)
     if (currentthinker->function == P_MobjThinker &&
   !(((mobj_t *) currentthinker)->flags & mask) && // killough 7/20/98
-        (((mobj_t *) currentthinker)->flags & MF_COUNTKILL ||
-         ((mobj_t *) currentthinker)->type == MT_SKULL))
+        (((mobj_t *) currentthinker)->flags & MF_ISMONSTER))
       { // killough 3/6/98: kill even if PE is dead
         if (((mobj_t *) currentthinker)->health > 0)
           {

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -709,7 +709,7 @@ static boolean PIT_FindTarget(mobj_t *mo)
   mobj_t *actor = current_actor;
 
   if (!((mo->flags ^ actor->flags) & MF_FRIEND &&        // Invalid target
-  mo->health > 0 && (mo->flags & MF_COUNTKILL || mo->type == MT_SKULL)))
+  mo->health > 0 && (mo->flags & MF_ISMONSTER)))
     return TRUE;
 
   // If the monster is already engaged in a one-on-one attack

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -208,28 +208,19 @@ static boolean P_CheckMissileRange(mobj_t *actor)
 
   dist >>= FRACBITS;
 
-  if (actor->type == MT_VILE)
-    if (dist > 14*64)
-      return FALSE;     // too far away
+  if (actor->info->maxattackrange > 0 && dist > actor->info->maxattackrange)
+    return FALSE;     // too far away
 
+  if (actor->info->meleestate != S_NULL && dist < actor->info->meleethreshold)
+    return false;     // close enough for melee attack, don't fire
 
-  if (actor->type == MT_UNDEAD)
-    {
-      if (dist < 196)
-        return FALSE;   // close for fist attack
-      dist >>= 1;
-    }
-
-  if (actor->type == MT_CYBORG ||
-      actor->type == MT_SPIDER ||
-      actor->type == MT_SKULL)
+  // higher attack probability like Cyberdemon, Spiderboss, Revenant and Lost Soul
+  if (actor->flags & MF_MISSILEMORE)
     dist >>= 1;
 
-  if (dist > 200)
-    dist = 200;
-
-  if (actor->type == MT_CYBORG && dist > 160)
-    dist = 160;
+  // Some mobs (eg. Cyberdemon) have a minimum attack chance
+  if (dist > actor->info->minmissilechance)
+    dist = actor->info->minmissilechance;
 
   if (P_Random(pr_missrange) < dist)
     return FALSE;
@@ -2107,7 +2098,7 @@ void A_BossDeath(mobj_t *mo)
   else
     {
       // e6y
-      // Additional check of gameepisode is necessary, because 
+      // Additional check of gameepisode is necessary, because
       // there is no right or wrong solution for E4M6 in original EXEs,
       // there's nothing to emulate.
       if (comp[comp_666] && gameepisode < 4)
@@ -2119,7 +2110,7 @@ void A_BossDeath(mobj_t *mo)
         // http://www.doomworld.com/idgames/index.php?id=6909
         if (gamemap != 8)
           return;
-        if (mo->type == MT_BRUISER && gameepisode != 1) 
+        if (mo->type == MT_BRUISER && gameepisode != 1)
           return;
       }
       else

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -1056,7 +1056,7 @@ void A_Look(mobj_t *actor)
           sound = actor->info->seesound;
           break;
         }
-      if (actor->type==MT_SPIDER || actor->type == MT_CYBORG)
+      if (actor->flags & MF_FULLVOLSIGHT)
         S_StartSound(NULL, sound);          // full volume
       else
         S_StartSound(actor, sound);
@@ -2043,7 +2043,7 @@ void A_Scream(mobj_t *actor)
     }
 
   // Check for bosses.
-  if (actor->type==MT_SPIDER || actor->type == MT_CYBORG)
+  if (actor->flags & MF_FULLVOLDEATH)
     S_StartSound(NULL, sound); // full volume
   else
     S_StartSound(actor, sound);

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -852,8 +852,8 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
 
   /* killough 9/9/98: cleaned up, made more consistent: */
 
-  if (source && source != target && source->type != MT_VILE &&
-      (!target->threshold || target->type == MT_VILE) &&
+  if (source && source != target && !(source->flags & MF_NOTARGET) &&
+      (!target->threshold || (target->flags & MF_QUICKTORETALIATE)) &&
       ((source->flags ^ target->flags) & MF_FRIEND ||
        monster_infighting ||
        !mbf_features))

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -615,7 +615,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
 {
   target->flags &= ~(MF_SHOOTABLE|MF_FLOAT|MF_SKULLFLY);
 
-  if (target->type != MT_SKULL)
+  if (!(target->flags & MF_DONTFALL))
     target->flags &= ~MF_NOGRAVITY;
 
   target->flags |= MF_CORPSE|MF_DROPOFF;

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -613,9 +613,6 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 // killough 11/98: make static
 static void P_KillMobj(mobj_t *source, mobj_t *target)
 {
-  mobjtype_t item;
-  mobj_t     *mo;
-
   target->flags &= ~(MF_SHOOTABLE|MF_FLOAT|MF_SKULLFLY);
 
   if (target->type != MT_SKULL)
@@ -699,28 +696,12 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
   // Drop stuff.
   // This determines the kind of object spawned
   // during the death frame of a thing.
-
-  switch (target->type)
-    {
-    case MT_WOLFSS:
-    case MT_POSSESSED:
-      item = MT_CLIP;
-      break;
-
-    case MT_SHOTGUY:
-      item = MT_SHOTGUN;
-      break;
-
-    case MT_CHAINGUY:
-      item = MT_CHAINGUN;
-      break;
-
-    default:
-      return;
-    }
-
-  mo = P_SpawnMobj (target->x,target->y,ONFLOORZ, item);
-  mo->flags |= MF_DROPPED;    // special versions of items
+  if (target->info->droppeditem != MT_NULL)
+  {
+    mobj_t     *mo;
+    mo = P_SpawnMobj (target->x,target->y,ONFLOORZ, target->info->droppeditem);
+    mo->flags |= MF_DROPPED;    // special versions of items
+  }
 }
 
 //

--- a/src/p_map.c
+++ b/src/p_map.c
@@ -1790,8 +1790,8 @@ boolean PIT_RadiusAttack (mobj_t* thing)
   // fired by Cyberdemons, in which case it won't hurt Cybers.
 
   if (bombspot->flags & MF_BOUNCES ?
-      thing->type == MT_CYBORG && bombsource->type == MT_CYBORG :
-      thing->type == MT_CYBORG || thing->type == MT_SPIDER)
+      thing->type == MT_CYBORG && bombsource->type == MT_CYBORG : // fixme: dehardcoding this might require complevel handling
+      (thing->flags & MF_NORADIUSDMG))
     return TRUE;
 
   dx = D_abs(thing->x - bombspot->x);

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -1277,7 +1277,7 @@ void P_SpawnMapThing (const mapthing_t* mthing)
 
   // don't spawn any monsters if -nomonsters
 
-  if (nomonsters && (i == MT_SKULL || (mobjinfo[i].flags & MF_COUNTKILL)))
+  if (nomonsters && (mobjinfo[i].flags & MF_ISMONSTER))
     return;
 
   // spawn it

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -231,6 +231,11 @@
 
 // higher attack probability like Cyberdemon, Spiderboss, Revenant and Lost Soul
 #define MF_MISSILEMORE  LONGLONG(0x0000040000000000)
+// play full volume sounds on player sight and death (eg. Spider & Cyberdemon)
+#define MF_FULLVOLSIGHT    LONGLONG(0x0000080000000000)
+#define MF_FULLVOLDEATH    LONGLONG(0x0000100000000000)
+// make immunity to radius damage
+#define MF_NORADIUSDMG     LONGLONG(0x0000200000000000)
 
 #define ALIVE(thing) ((thing->health > 0) && ((thing->flags & (MF_COUNTKILL | MF_CORPSE | MF_RESURRECTED)) == MF_COUNTKILL))
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -226,6 +226,12 @@
 
 #define MF_PLAYERSPRITE LONGLONG(0x0000008000000000)
 
+#define MF_NOTARGET     LONGLONG(0x0000010000000000) // unused, prboom+ compat
+#define MF_FLY          LONGLONG(0x0000020000000000) // unused, prboom+ compat
+
+// higher attack probability like Cyberdemon, Spiderboss, Revenant and Lost Soul
+#define MF_MISSILEMORE  LONGLONG(0x0000040000000000)
+
 #define ALIVE(thing) ((thing->health > 0) && ((thing->flags & (MF_COUNTKILL | MF_CORPSE | MF_RESURRECTED)) == MF_COUNTKILL))
 
 // killough 9/15/98: Same, but internal flags, not intended for .deh
@@ -411,4 +417,3 @@ void    P_SpawnPlayer(int n, const mapthing_t *mthing);
 void    P_CheckMissileSpawn(mobj_t*);  // killough 8/2/98
 void    P_ExplodeMissile(mobj_t*);    // killough
 #endif
-

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -226,7 +226,8 @@
 
 #define MF_PLAYERSPRITE LONGLONG(0x0000008000000000)
 
-#define MF_NOTARGET     LONGLONG(0x0000010000000000) // unused, prboom+ compat
+// This actor not targetted when it hurts something else
+#define MF_NOTARGET     LONGLONG(0x0000010000000000)
 #define MF_FLY          LONGLONG(0x0000020000000000) // unused, prboom+ compat
 
 // higher attack probability like Cyberdemon, Spiderboss, Revenant and Lost Soul
@@ -236,6 +237,8 @@
 #define MF_FULLVOLDEATH    LONGLONG(0x0000100000000000)
 // make immunity to radius damage
 #define MF_NORADIUSDMG     LONGLONG(0x0000200000000000)
+// Arch Viles will immediately switch target if being attacked.
+#define MF_QUICKTORETALIATE LONGLONG(0x0000400000000000)
 
 #define ALIVE(thing) ((thing->health > 0) && ((thing->flags & (MF_COUNTKILL | MF_CORPSE | MF_RESURRECTED)) == MF_COUNTKILL))
 

--- a/src/p_mobj.h
+++ b/src/p_mobj.h
@@ -239,6 +239,10 @@
 #define MF_NORADIUSDMG     LONGLONG(0x0000200000000000)
 // Arch Viles will immediately switch target if being attacked.
 #define MF_QUICKTORETALIATE LONGLONG(0x0000400000000000)
+// flag for monsters since there can be some without MF_COUNTKILL (Lost Souls)
+#define MF_ISMONSTER		    LONGLONG(0x0000800000000000)
+// doesn't fall down after being killed (for the Lost Soul)
+#define MF_DONTFALL		      LONGLONG(0x0001000000000000)
 
 #define ALIVE(thing) ((thing->health > 0) && ((thing->flags & (MF_COUNTKILL | MF_CORPSE | MF_RESURRECTED)) == MF_COUNTKILL))
 

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -88,8 +88,7 @@ void P_UpdateThinker(thinker_t *thinker)
     thinker->function == P_RemoveThinkerDelayed ? th_delete :
     thinker->function == P_MobjThinker &&
     ((mobj_t *) thinker)->health > 0 &&
-    (((mobj_t *) thinker)->flags & MF_COUNTKILL ||
-     ((mobj_t *) thinker)->type == MT_SKULL) ?
+    (((mobj_t *) thinker)->flags & MF_ISMONSTER) ?
     ((mobj_t *) thinker)->flags & MF_FRIEND ?
     th_friends : th_enemies : th_misc;
 
@@ -310,4 +309,3 @@ void P_Ticker (void)
   P_MapEnd();
   leveltime++;                       // for par times
 }
-


### PR DESCRIPTION
This will add several new flags and properties for the monster behavior so they can be customized through dehacked, and remove some hardwired logic for specific monsters.

Most of the flags are equivalent to their ZDoom counterparts (ZDoom's [flags ](https://zdoom.org/wiki/Actor_flags) and [properties](https://zdoom.org/wiki/Actor_properties)). And they are placed to be compatible with Graf Zahl's PrBoom+ fork. The "Dropped item" property is just like the one from Doom Retro [dehacked extension ](https://github.com/bradharding/doomretro/wiki/INFORMATION-FOR-MAPPERS#DEHACKED-LUMPS).

New dehacked properties:

- Dropped Item
   Specify the id of the item to be dropped when dying. The value should
   be -1 for no item dropped.

- Melee Threshold
    The actor with this property set will not attack its target with a
    missile attack if it is within the specified range, but rather (if
    chasing) attempt to close in to engage in melee.

- Max Target Range
    A monster with this property set will not attack its target unless
    it is within the specified range.

- Min Missile Chance
    This is one part of the missile attack probability calculation. The
    lower this value is the more aggressive the monster is. This can be
    combined with the MISSILEMORE. Default 200.

New Mobj flags:

- MISSILEMORE
    Increases (doubles) the probability of a missile attack from farther away (like Cyberdemons, Spider Mastermind and Lost Souls)

- FULLVOLSIGHT
   Plays its alert sound at full volume (Cyber and Spider)

- FULLVOLDEATH
   Plays its death sound at full volume (Cyber and Spider)

- NORADIUSDMG
   Radius (explosive) damage doesnt harm it (Cyber and Spider)

- NOTARGET
   actor won't be targetted even if it hurts someone else (like Archvile)

- QUICKTORETALIATE
   actor will immediately switch target if attacked (like Archvile)

- ISMONSTER
   for all monsters, even those that don't count in the level's kill
   percentage

- DONTFALL
   won't fall down to the floor after being killed even if it's flying (like Lost Souls)

