### PR TITLE
Sigil title theme

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -374,6 +374,8 @@ static void D_DrawTitle1(const char *name)
 {
   S_StartMusic(mus_intro);
   pagetic = (TICRATE*170)/35;
+  if (W_CheckNumForName("SIGILINT")) // Sigil: Longer wait before playing a demo to give the title theme time to end.
+    pagetic = (TICRATE*404)/35;
   D_SetPageName(name);
 }
 

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -374,7 +374,7 @@ static void D_DrawTitle1(const char *name)
 {
   S_StartMusic(mus_intro);
   pagetic = (TICRATE*170)/35;
-  if (W_CheckNumForName("SIGILINT")) // Sigil: Longer wait before playing a demo to give the title theme time to end.
+  if (W_CheckNumForName("SIGILINT") != -1) // Sigil: Longer wait before playing a demo to give the title theme time to end.
     pagetic = (TICRATE*404)/35;
   D_SetPageName(name);
 }


### PR DESCRIPTION
Sigil title theme is much longer than Doom, so it was being cut off because the wait time to start a demo is not automatic depending the duration of the song. I added a check so if a lump named "SIGILINT" (Sigil intermission background) is detected the wait time will be longer giving Sigil title theme time to end.
This will fix #102 