### PR TITLE
Smoother framerate and interpolation for moving sectors, doors and scrolling walls

### DIFF
--- a/src/d_client.c
+++ b/src/d_client.c
@@ -544,11 +544,6 @@ void TryRunTics(void)
 
   D_BuildNewTiccmds();
 
-  if (movement_smooth && gamestate==wipegamestate) {
-    WasRenderedInTryRunTics = TRUE;
-    D_Display();
-  }
-
   if(tic_vars.frac == FRACUNIT) {
     tic_vars.frac = overflow;
     if (advancedemo)
@@ -558,7 +553,6 @@ void TryRunTics(void)
     P_Checksum(gametic);
     gametic++;
   }
-
 }
 
 #endif

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -536,10 +536,14 @@ void D_BuildNewTiccmds(void)
 void TryRunTics(void)
 {
   fixed_t overflow = 0;
-  tic_vars.frac += tic_vars.frac_step;
-  if(tic_vars.frac > FRACUNIT) {
-    overflow = tic_vars.frac - FRACUNIT;
-    tic_vars.frac = FRACUNIT;
+  // Increment tic fraction if game is ongoing
+  if ((demoplayback || !menuactive) && !paused)
+  {
+     tic_vars.frac += tic_vars.frac_step;
+     if(tic_vars.frac > FRACUNIT) {
+        overflow = tic_vars.frac - FRACUNIT;
+        tic_vars.frac = FRACUNIT;
+     }
   }
 
   D_BuildNewTiccmds();

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -652,9 +652,8 @@ boolean G_Responder (event_t* ev)
     ST_Start();    // killough 3/7/98: switch status bar views too
     HU_Start();
     S_UpdateSounds(players[displayplayer].mo);
-#ifndef __LIBRETRO__
+
     R_ActivateSectorInterpolations();
-#endif
     R_SmoothPlaying_Reset(NULL);
   }
       return TRUE;

--- a/src/p_setup.c
+++ b/src/p_setup.c
@@ -1748,9 +1748,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
    char  gl_lumpname[9];
    int   gl_lumpnum;
 
-#ifndef __LIBRETRO__
    R_StopAllInterpolations();
-#endif
 
    totallive = totalkills = totalitems = totalsecret = wminfo.maxfrags = 0;
    wminfo.partime = 180;

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -187,9 +187,7 @@ void P_RemoveThinkerDelayed(thinker_t *thinker)
 
 void P_RemoveThinker(thinker_t *thinker)
 {
-#ifndef __LIBRETRO__
   R_StopInterpolationIfNeeded(thinker);
-#endif
   thinker->function = P_RemoveThinkerDelayed;
 
   P_UpdateThinker(thinker);
@@ -257,10 +255,8 @@ static void P_RunThinkers (void)
        currentthinker != &thinkercap;
        currentthinker = currentthinker->next)
   {
-#ifndef __LIBRETRO__
     if (newthinkerpresent)
       R_ActivateThinkerInterpolations(currentthinker);
-#endif
     if (currentthinker->function)
       currentthinker->function(currentthinker);
   }
@@ -292,9 +288,7 @@ void P_Ticker (void)
      players[consoleplayer].viewz != 1))
     return;
 
-#ifndef __LIBRETRO__
   R_UpdateInterpolations ();
-#endif
 
   P_MapStart();
                // not if this is an intermission screen

--- a/src/r_demo.c
+++ b/src/r_demo.c
@@ -83,8 +83,6 @@ angle_t R_SmoothPlaying_Get(angle_t defangle)
 
 void R_ResetAfterTeleport(player_t *player)
 {
-#ifndef __LIBRETRO__
   R_ResetViewInterpolation();
-#endif
   R_SmoothPlaying_Reset(player);
 }

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -122,20 +122,6 @@ void R_InterpolateView (player_t *player)
     viewangle = R_SmoothPlaying_Get(player->mo->angle) + viewangleoffset;
     viewpitch = R_SmoothPlaying_Get(player->mo->pitch) + viewpitchoffset;
   }
-
-  if (!paused && movement_smooth)
-  {
-    int i;
-
-    didInterp = frac != FRACUNIT;
-    if (didInterp)
-    {
-      for (i = numinterpolations - 1; i >= 0; i--)
-      {
-        R_DoAnInterpolation (i, frac);
-      }
-    }
-  }
 }
 
 void R_ResetViewInterpolation ()

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -83,10 +83,6 @@ int      fieldofview;
 fixed_t  freelookviewheight;
 extern lighttable_t **walllights;
 
-#ifndef __LIBRETRO__
-static mobj_t *oviewer;
-#endif
-
 //
 // precalculated math tables
 //
@@ -680,7 +676,5 @@ void R_RenderPlayerView (player_t* player)
   NetUpdate ();
 #endif
 
-#ifndef __LIBRETRO__
   R_RestoreInterpolations();
-#endif
 }


### PR DESCRIPTION
I believe this should help with (hopefully fix?) the issues raised on https://forums.libretro.com/t/doom-prboom-60fps-option-not-working-in-game/22983/7 

Also I fixed and enabled the interpolation for doors and other map elements that was buggy before.
So now they should no longer stay at 35 fps.