### PR TITLE
Add UMAPINFO support

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -112,7 +112,10 @@ SOURCES_C += $(CORE_DIR)/am_map.c \
 				 $(CORE_DIR)/oplplayer.c \
 				 $(CORE_DIR)/flplayer.c \
 				 $(CORE_DIR)/midifile.c \
-				 $(CORE_DIR)/madplayer.c
+				 $(CORE_DIR)/madplayer.c \
+				 $(CORE_DIR)/u_mapinfo.c \
+				 $(CORE_DIR)/u_scanner.c \
+
 
 ifeq ($(WANT_FLUIDSYNTH), 1)
 FLUIDSYNTH_DIR := $(DEPS_DIR)/fluidlite

--- a/doc/umapinfo.txt
+++ b/doc/umapinfo.txt
@@ -1,0 +1,65 @@
+UMAPINFO uses an ini-like syntax.
+A map is defined with
+
+MAP mapname
+{
+	key = value
+	key = value1, value2,...
+	...
+}
+
+entries. Values can be strings, enclosed in quotation marks ("), numbers or identifiers. Identifiers are case insensitive names that start with a letter and may only contain letters, numbers or the underscore ('_')
+
+The map names are limited to the format of the currently loaded IWAD, i.e. Doom 2 only supports MAPxx entries and Doom 1 only ExMy entries.
+The numbers x and y can exceed their original limits, though, so MAP50, E5M6 or even MAP100 or E1M10 are valid map names for their respective game.
+This limit comes from the game using numeric variables 'gameepisode' and 'gamemap' to identify a level. It may later be decided to lift the naming restriction but this cannot be done without some extensive refactoring which simply exceeds the scope of the initial implementation.
+
+Currently the follwing keys are supported. If not given, the hardcoded default will be used, unless the following list says differently.
+
+levelname = "name"			; Specifies the readable name of the level (e.g. "Hangar") This will be used in the automap and also on the status screen if no name patch is specified.
+levelpic = "graphic"		; Specifes the patch that is used on the status screen for 'entering' and 'finished'. This can be omitted, in that case the levelname will be printed with the HUD font.
+next = "mapname"			; Specifies the map the regular exit leads to. In Doom 1 this may cross episodes.
+nextsecret = "mapname"		; Specifies the map the secret exit leads to. In Doom 1 this may cross episodes.
+skytexture = "texture"		; Specifies the sky texture to be used for this map.
+music = "song"				; Specifies the music to be played on this map.
+exitpic = "graphic"			; Specifies the background for the 'level finished' screen. This can override Doom's animated screens for E1-3.
+enterpic = "graphic"		; Specifies the background for the 'entering level' screen. This can override Doom's animated screens for E1-3.
+partime = seconds			; Specifies the level's par time.
+endgame = false				; Overrides a default map exit (e.g. ExM8 or MAP30)
+endgame = true				; Ends the game after this level, showing the default post-game screen for the current episode.
+endpic = "graphic"			; Ends the game after this level, showing the specified graphic as an end screen.
+endbunny = true				; Ends the game after this level, showing the bunny scroller.
+endcast = true				; Ends the game after this level, showing the cast call.
+nointermission = true/false ; Currently only working for levels that end the game: When true skips the 'level finished' screen.
+intertext = "text"			; Shows an intermission text screen after the level is exited through the regular exit. "text" can be multiple lines, for ease of reading they can be specified as multiple parameters over several lines (see example below.)
+intertext = clear			; Disables default intermission text for the given map (e.g. to go from MAP06 to MAP07 without a text showing up.)
+intertextsecret = "text"	; Shows an intermission text screen after the level is exited through the secret exit. This will never default to 'intertext'. If not given, the defaults will be used
+intertextsecret = clear		; Disables default intermission text for the given map's secret exit.
+interbackdrop = "flat"		; Backdrop to be used for intertext and intertextsecret. If not specified FLOOR4_8 will be used, regardless of which map it is used on.
+intermusic = "song"			; Music to be used for intertext and intertextsecret. If not specified D_VICTOR/D_READ_M will be used, depending on the IWAD.
+episode = clear				; Clears the episode menu of all previous entries. Should be used on the first map if a mod wants to define its own episodes.
+episode = "patch", "name", "key"	
+							; Defines an entry for the episode menu. If all defined episodes define a valid patch, those will be shown, otherwise the names will be used with the HUD font. At most 8 episodes can be defined.
+bossaction = thingtype, linespecial, tag
+							; Defines a boss death action. Tag 0 is not allowed except for level exits. Shoot triggers, teleporters and locked doors are not supported. A map may define multiple death actions. Thingtype uses ZDoom's class names (see list below.)
+
+
+Default handling:
+
+Normally, if some information cannot be found, the engine will fall back to its hard coded implementation, with a few exceptions:
+
+- nextsecret: If not present, it will use the normal exit's map if the current map has a MAPINFO record. This also applies to maps which by default have a secret exit!
+- enterpic: If the map that was just left has an exitpic entry and the map to be entered has no enterpic entry, the previous map's exitpic entry will be used for both screens.
+- levelpic: If not given, the status screen will instead print the map's name with a suitable font (PrBoom uses STFxxx) to ensure that the proper name is used.
+- interbackdrop: This will not look up the default backdrop for a given map but always use FLOOR4_8.
+
+Example:
+
+MAP E1M7
+{
+	levelname = "The Hidden Cave"
+	skytexture =  "sky2"
+	intertext = "You have beaten the shit",
+		"out of those big barons",
+		"and now must continue the fight."
+}

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -95,7 +95,7 @@ static char *dehfgets(char *buf, size_t n, DEHFILE *fp)
   else
     {                                                // copy buffer
       char *p = buf;
-      while (n>1 && *fp->inp && fp->size &&
+      while (n>1 && fp->size && *fp->inp &&
              (n--, fp->size--, *p++ = *fp->inp++) != '\n')
         ;
       *p = 0;
@@ -105,7 +105,7 @@ static char *dehfgets(char *buf, size_t n, DEHFILE *fp)
 
 static int dehfeof(DEHFILE *fp)
 {
-  return !fp->lump ? feof(fp->f) : !*fp->inp || fp->size<=0;
+  return !fp->lump ? feof(fp->f) : fp->size<=0 || !*fp->inp;
 }
 
 static int dehfgetc(DEHFILE *fp)

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -82,6 +82,7 @@
 #include "d_deh.h"  // Ty 04/08/98 - Externalizations
 #include "lprintf.h"  // jff 08/03/98 - declaration of lprintf
 #include "am_map.h"
+#include "u_mapinfo.h"
 
 void GetFirstMap(int *ep, int *map); // Ty 08/29/98 - add "-warp x" functionality
 static void D_PageDrawer(void);
@@ -1414,6 +1415,17 @@ bool D_DoomMainSetup(void)
   lprintf(LO_INFO,"M_Init: Init miscellaneous info.\n");
   M_Init();
 
+  // if not explicitly disabled, load UMAPINFO
+  if (!M_CheckParm("-nomapinfo"))
+  {
+    for (p = -1; (p = W_ListNumFromName("UMAPINFO", p)) >= 0; )
+    {
+      const char *data = (const char *)W_CacheLumpNum(p);
+      U_ParseMapInfo(data, W_LumpLength(p));
+    }
+  }
+
+
 #ifdef HAVE_NET
   // CPhipps - now wait for netgame start
   D_CheckNetGame();
@@ -1522,6 +1534,7 @@ void D_DoomDeinit(void)
 #endif
   M_SaveDefaults ();
   W_Exit();
+  U_FreeMapInfo();
   I_ShutdownSound();
   I_ShutdownMusic();
   p_checksum_cleanup();

--- a/src/d_player.h
+++ b/src/d_player.h
@@ -52,6 +52,9 @@
 // as commands per game tick.
 #include "d_ticcmd.h"
 
+// Keep track of the player's map entry
+#include "u_mapinfo.h"
+
 //
 // Player states.
 //
@@ -215,6 +218,9 @@ typedef struct
   // previous and next levels, origin 0
   int         last;
   int         next;
+  int         nextep;	// for when MAPINFO progression crosses into another episode.
+  mapentry_t* lastmapinfo;
+  mapentry_t* nextmapinfo;
 
   int         maxkills;
   int         maxitems;

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -42,6 +42,9 @@
 // We need the playr data structure as well.
 #include "d_player.h"
 
+// and mapinfo information
+#include "u_mapinfo.h"
+
 // ------------------------
 // Command line parameters.
 //
@@ -127,6 +130,7 @@ extern  boolean   autostart;
 extern  skill_t         gameskill;
 extern  int   gameepisode;
 extern  int   gamemap;
+extern  mapentry_t*     gamemapinfo;
 
 // Nightmare mode flag, single player.
 extern  boolean         respawnmonsters;

--- a/src/g_game.h
+++ b/src/g_game.h
@@ -81,6 +81,7 @@ void G_BuildTiccmd (ticcmd_t* cmd); // CPhipps - move decl to header
 void G_ChangedPlayerColour(int pn, int cl); // CPhipps - On-the-fly player colour changing
 void G_MakeSpecialEvent(buttoncode_t bc, ...); /* cph - new event stuff */
 int  G_CheckNumForLevel(int episode, int map);
+int  G_ValidateMapName(const char *mapname, int *pEpi, int *pMap);
 
 // killough 1/18/98: Doom-style printf;   killough 4/25/98: add gcc attributes
 // CPhipps - renames to doom_printf to avoid name collision with glibc

--- a/src/hu_stuff.c
+++ b/src/hu_stuff.c
@@ -512,21 +512,36 @@ void HU_Start(void)
   );
 
   // initialize the automap's level title widget
-  if (gamestate == GS_LEVEL) /* cph - stop SEGV here when not in level */
-  switch (gamemode)
+  s = NULL;
+  if (gamemapinfo != NULL)
   {
-    case shareware:
-    case registered:
-    case retail:
-      s = HU_TITLE;
-      break;
+    s = gamemapinfo->mapname;
+    while (*s)
+      HUlib_addCharToTextLine(&w_title, *(s++));
 
-    case commercial:
-    default:  // Ty 08/27/98 - modified to check mission for TNT/Plutonia
-      s = (gamemission==pack_tnt)  ? HU_TITLET :
-          (gamemission==pack_plut) ? HU_TITLEP : HU_TITLE2;
-      break;
-  } else s = "";
+    HUlib_addCharToTextLine(&w_title, ':');
+    HUlib_addCharToTextLine(&w_title, ' ');
+    s = gamemapinfo->levelname;
+  }
+  else
+  {
+    if (gamestate == GS_LEVEL) /* cph - stop SEGV here when not in level */
+    switch (gamemode)
+    {
+      case shareware:
+      case registered:
+      case retail:
+        s = HU_TITLE;
+        break;
+
+      case commercial:
+      default:  // Ty 08/27/98 - modified to check mission for TNT/Plutonia
+        s = (gamemission==pack_tnt)  ? HU_TITLET :
+            (gamemission==pack_plut) ? HU_TITLEP : HU_TITLE2;
+        break;
+    }
+  }
+  if (!s) s = "Unnamed";
   while (*s)
     HUlib_addCharToTextLine(&w_title, *(s++));
 

--- a/src/info.c
+++ b/src/info.c
@@ -1217,6 +1217,7 @@ state_t states[NUMSTATES] = {
 
 mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   {   // MT_PLAYER
+     "DoomPlayer", // actorname
     -1,   // doomednum
     S_PLAY,   // spawnstate
     100,    // spawnhealth
@@ -1247,6 +1248,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_POSSESSED
+    "ZombieMan", // actorname
     3004,   // doomednum
     S_POSS_STND,    // spawnstate
     20,   // spawnhealth
@@ -1277,6 +1279,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SHOTGUY
+    "ShotgunGuy", // actorname
     9,    // doomednum
     S_SPOS_STND,    // spawnstate
     30,   // spawnhealth
@@ -1307,6 +1310,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_VILE
+    "Archvile", // actorname
     64,   // doomednum
     S_VILE_STND,    // spawnstate
     700,    // spawnhealth
@@ -1337,6 +1341,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_FIRE
+    "ArchvileFire", // actorname
     -1,   // doomednum
     S_FIRE1,    // spawnstate
     1000,   // spawnhealth
@@ -1367,6 +1372,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_UNDEAD
+    "Revenant", // actorname
     66,   // doomednum
     S_SKEL_STND,    // spawnstate
     300,    // spawnhealth
@@ -1397,6 +1403,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_TRACER
+    "RevenantTracer", // actorname
     -1,   // doomednum
     S_TRACER,   // spawnstate
     1000,   // spawnhealth
@@ -1427,6 +1434,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SMOKE
+    "RevenantTracerSmoke", // actorname
     -1,   // doomednum
     S_SMOKE1,   // spawnstate
     1000,   // spawnhealth
@@ -1457,6 +1465,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_FATSO
+    "Fatso", // actorname
     67,   // doomednum
     S_FATT_STND,    // spawnstate
     600,    // spawnhealth
@@ -1487,6 +1496,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_FATSHOT
+    "FatShot", // actorname
     -1,   // doomednum
     S_FATSHOT1,   // spawnstate
     1000,   // spawnhealth
@@ -1517,6 +1527,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_CHAINGUY
+    "ChaingunGuy", // actorname
     65,   // doomednum
     S_CPOS_STND,    // spawnstate
     70,   // spawnhealth
@@ -1547,6 +1558,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_TROOP
+    "DoomImp", // actorname
     3001,   // doomednum
     S_TROO_STND,    // spawnstate
     60,   // spawnhealth
@@ -1577,6 +1589,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SERGEANT
+    "Demon", // actorname
     3002,   // doomednum
     S_SARG_STND,    // spawnstate
     150,    // spawnhealth
@@ -1607,6 +1620,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SHADOWS
+    "Spectre", // actorname
     58,   // doomednum
     S_SARG_STND,    // spawnstate
     150,    // spawnhealth
@@ -1637,6 +1651,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_HEAD
+    "Cacodemon", // actorname
     3005,   // doomednum
     S_HEAD_STND,    // spawnstate
     400,    // spawnhealth
@@ -1667,6 +1682,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BRUISER
+    "BaronOfHell", // actorname
     3003,   // doomednum
     S_BOSS_STND,    // spawnstate
     1000,   // spawnhealth
@@ -1697,6 +1713,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BRUISERSHOT
+    "BaronBall", // actorname
     -1,   // doomednum
     S_BRBALL1,    // spawnstate
     1000,   // spawnhealth
@@ -1727,6 +1744,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_KNIGHT
+    "HellKnight", // actorname
     69,   // doomednum
     S_BOS2_STND,    // spawnstate
     500,    // spawnhealth
@@ -1757,6 +1775,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SKULL
+    "LostSoul", // actorname
     3006,   // doomednum
     S_SKULL_STND,   // spawnstate
     100,    // spawnhealth
@@ -1787,6 +1806,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SPIDER
+    "SpiderMastermind", // actorname
     7,    // doomednum
     S_SPID_STND,    // spawnstate
     3000,   // spawnhealth
@@ -1817,6 +1837,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BABY
+    "Arachnotron", // actorname
     68,   // doomednum
     S_BSPI_STND,    // spawnstate
     500,    // spawnhealth
@@ -1847,6 +1868,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_CYBORG
+    "Cyberdemon", // actorname
     16,   // doomednum
     S_CYBER_STND,   // spawnstate
     4000,   // spawnhealth
@@ -1877,6 +1899,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_PAIN
+    "PainElemental", // actorname
     71,   // doomednum
     S_PAIN_STND,    // spawnstate
     400,    // spawnhealth
@@ -1907,6 +1930,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_WOLFSS
+    "WolfensteinSS", // actorname
     84,   // doomednum
     S_SSWV_STND,    // spawnstate
     50,   // spawnhealth
@@ -1937,6 +1961,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_KEEN
+    "CommanderKeen", // actorname
     72,   // doomednum
     S_KEENSTND,   // spawnstate
     100,    // spawnhealth
@@ -1967,6 +1992,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BOSSBRAIN
+    "BossBrain", // actorname
     88,   // doomednum
     S_BRAIN,    // spawnstate
     250,    // spawnhealth
@@ -1997,6 +2023,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BOSSSPIT
+    "BossEye", // actorname
     89,   // doomednum
     S_BRAINEYE,   // spawnstate
     1000,   // spawnhealth
@@ -2027,6 +2054,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BOSSTARGET
+    "BossTarget", // actorname
     87,   // doomednum
     S_NULL,   // spawnstate
     1000,   // spawnhealth
@@ -2057,6 +2085,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SPAWNSHOT
+    "SpawnShot", // actorname
     -1,   // doomednum
     S_SPAWN1,   // spawnstate
     1000,   // spawnhealth
@@ -2087,6 +2116,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SPAWNFIRE
+    "SpawnFire", // actorname
     -1,   // doomednum
     S_SPAWNFIRE1,   // spawnstate
     1000,   // spawnhealth
@@ -2117,6 +2147,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BARREL
+    "ExplosiveBarrel", // actorname
     2035,   // doomednum
     S_BAR1,   // spawnstate
     20,   // spawnhealth
@@ -2147,6 +2178,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_TROOPSHOT
+    "DoomImpBall", // actorname
     -1,   // doomednum
     S_TBALL1,   // spawnstate
     1000,   // spawnhealth
@@ -2177,6 +2209,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_HEADSHOT
+    "CacodemonBall", // actorname
     -1,   // doomednum
     S_RBALL1,   // spawnstate
     1000,   // spawnhealth
@@ -2207,6 +2240,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_ROCKET
+    "Rocket", // actorname
     -1,   // doomednum
     S_ROCKET,   // spawnstate
     1000,   // spawnhealth
@@ -2237,6 +2271,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_PLASMA
+    "PlasmaBall", // actorname
     -1,   // doomednum
     S_PLASBALL,   // spawnstate
     1000,   // spawnhealth
@@ -2267,6 +2302,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BFG
+    "BFGBall", // actorname
     -1,   // doomednum
     S_BFGSHOT,    // spawnstate
     1000,   // spawnhealth
@@ -2297,6 +2333,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_ARACHPLAZ
+    "ArachnotronPlasma", // actorname
     -1,   // doomednum
     S_ARACH_PLAZ,   // spawnstate
     1000,   // spawnhealth
@@ -2327,6 +2364,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_PUFF
+    "BulletPuff", // actorname
     -1,   // doomednum
     S_PUFF1,    // spawnstate
     1000,   // spawnhealth
@@ -2357,6 +2395,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_BLOOD
+    "Blood", // actorname
     -1,   // doomednum
     S_BLOOD1,   // spawnstate
     1000,   // spawnhealth
@@ -2387,6 +2426,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_TFOG
+    "TeleportFog", // actorname
     -1,   // doomednum
     S_TFOG,   // spawnstate
     1000,   // spawnhealth
@@ -2417,6 +2457,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_IFOG
+    "ItemFog", // actorname
     -1,   // doomednum
     S_IFOG,   // spawnstate
     1000,   // spawnhealth
@@ -2447,6 +2488,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_TELEPORTMAN
+    "TeleportDest", // actorname
     14,   // doomednum
     S_NULL,   // spawnstate
     1000,   // spawnhealth
@@ -2477,6 +2519,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_EXTRABFG
+    "BFGExtra", // actorname
     -1,   // doomednum
     S_BFGEXP,   // spawnstate
     1000,   // spawnhealth
@@ -2507,6 +2550,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC0
+    "GreenArmor", // actorname
     2018,   // doomednum
     S_ARM1,   // spawnstate
     1000,   // spawnhealth
@@ -2537,6 +2581,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC1
+    "BlueArmor", // actorname
     2019,   // doomednum
     S_ARM2,   // spawnstate
     1000,   // spawnhealth
@@ -2567,6 +2612,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC2
+    "HealthBonus", // actorname
     2014,   // doomednum
     S_BON1,   // spawnstate
     1000,   // spawnhealth
@@ -2597,6 +2643,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC3
+    "ArmorBonus", // actorname
     2015,   // doomednum
     S_BON2,   // spawnstate
     1000,   // spawnhealth
@@ -2627,6 +2674,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC4
+    "BlueCard", // actorname
     5,    // doomednum
     S_BKEY,   // spawnstate
     1000,   // spawnhealth
@@ -2657,6 +2705,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC5
+    "RedCard", // actorname
     13,   // doomednum
     S_RKEY,   // spawnstate
     1000,   // spawnhealth
@@ -2687,6 +2736,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC6
+    "YellowCard", // actorname
     6,    // doomednum
     S_YKEY,   // spawnstate
     1000,   // spawnhealth
@@ -2717,6 +2767,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC7
+    "YellowSkull", // actorname
     39,   // doomednum
     S_YSKULL,   // spawnstate
     1000,   // spawnhealth
@@ -2747,6 +2798,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC8
+    "RedSkull", // actorname
     38,   // doomednum
     S_RSKULL,   // spawnstate
     1000,   // spawnhealth
@@ -2777,6 +2829,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC9
+    "BlueSkull", // actorname
     40,   // doomednum
     S_BSKULL,   // spawnstate
     1000,   // spawnhealth
@@ -2807,6 +2860,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC10
+    "Stimpack", // actorname
     2011,   // doomednum
     S_STIM,   // spawnstate
     1000,   // spawnhealth
@@ -2837,6 +2891,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC11
+    "Medikit", // actorname
     2012,   // doomednum
     S_MEDI,   // spawnstate
     1000,   // spawnhealth
@@ -2867,6 +2922,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC12
+    "Soulsphere", // actorname
     2013,   // doomednum
     S_SOUL,   // spawnstate
     1000,   // spawnhealth
@@ -2897,6 +2953,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_INV
+    "InvulnerabilitySphere", // actorname
     2022,   // doomednum
     S_PINV,   // spawnstate
     1000,   // spawnhealth
@@ -2927,6 +2984,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC13
+    "Berserk", // actorname
     2023,   // doomednum
     S_PSTR,   // spawnstate
     1000,   // spawnhealth
@@ -2957,6 +3015,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_INS
+    "BlurSphere", // actorname
     2024,   // doomednum
     S_PINS,   // spawnstate
     1000,   // spawnhealth
@@ -2987,6 +3046,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC14
+    "RadSuit", // actorname
     2025,   // doomednum
     S_SUIT,   // spawnstate
     1000,   // spawnhealth
@@ -3017,6 +3077,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC15
+    "Allmap", // actorname
     2026,   // doomednum
     S_PMAP,   // spawnstate
     1000,   // spawnhealth
@@ -3047,6 +3108,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC16
+    "Infrared", // actorname
     2045,   // doomednum
     S_PVIS,   // spawnstate
     1000,   // spawnhealth
@@ -3077,6 +3139,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MEGA
+    "Megasphere", // actorname
     83,   // doomednum
     S_MEGA,   // spawnstate
     1000,   // spawnhealth
@@ -3107,6 +3170,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_CLIP
+    "Clip", // actorname
     2007,   // doomednum
     S_CLIP,   // spawnstate
     1000,   // spawnhealth
@@ -3137,6 +3201,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC17
+    "ClipBox", // actorname
     2048,   // doomednum
     S_AMMO,   // spawnstate
     1000,   // spawnhealth
@@ -3167,6 +3232,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC18
+    "RocketAmmo", // actorname
     2010,   // doomednum
     S_ROCK,   // spawnstate
     1000,   // spawnhealth
@@ -3197,6 +3263,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC19
+    "RocketBox", // actorname
     2046,   // doomednum
     S_BROK,   // spawnstate
     1000,   // spawnhealth
@@ -3227,6 +3294,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC20
+    "Cell", // actorname
     2047,   // doomednum
     S_CELL,   // spawnstate
     1000,   // spawnhealth
@@ -3257,6 +3325,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC21
+    "CellPack", // actorname
     17,   // doomednum
     S_CELP,   // spawnstate
     1000,   // spawnhealth
@@ -3287,6 +3356,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC22
+    "Shell", // actorname
     2008,   // doomednum
     S_SHEL,   // spawnstate
     1000,   // spawnhealth
@@ -3317,6 +3387,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC23
+    "ShellBox", // actorname
     2049,   // doomednum
     S_SBOX,   // spawnstate
     1000,   // spawnhealth
@@ -3347,6 +3418,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC24
+    "Backpack", // actorname
     8,    // doomednum
     S_BPAK,   // spawnstate
     1000,   // spawnhealth
@@ -3377,6 +3449,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC25
+    "BFG9000", // actorname
     2006,   // doomednum
     S_BFUG,   // spawnstate
     1000,   // spawnhealth
@@ -3407,6 +3480,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_CHAINGUN
+    "Chaingun", // actorname
     2002,   // doomednum
     S_MGUN,   // spawnstate
     1000,   // spawnhealth
@@ -3437,6 +3511,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC26
+    "Chainsaw", // actorname
     2005,   // doomednum
     S_CSAW,   // spawnstate
     1000,   // spawnhealth
@@ -3467,6 +3542,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC27
+    "RocketLauncher", // actorname
     2003,   // doomednum
     S_LAUN,   // spawnstate
     1000,   // spawnhealth
@@ -3497,6 +3573,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC28
+    "PlasmaRifle", // actorname
     2004,   // doomednum
     S_PLAS,   // spawnstate
     1000,   // spawnhealth
@@ -3527,6 +3604,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SHOTGUN
+    "Shotgun", // actorname
     2001,   // doomednum
     S_SHOT,   // spawnstate
     1000,   // spawnhealth
@@ -3557,6 +3635,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_SUPERSHOTGUN
+    "SuperShotgun", // actorname
     82,   // doomednum
     S_SHOT2,    // spawnstate
     1000,   // spawnhealth
@@ -3587,6 +3666,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC29
+    "TechLamp", // actorname
     85,   // doomednum
     S_TECHLAMP,   // spawnstate
     1000,   // spawnhealth
@@ -3617,6 +3697,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC30
+    "TechLamp2", // actorname
     86,   // doomednum
     S_TECH2LAMP,    // spawnstate
     1000,   // spawnhealth
@@ -3647,6 +3728,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC31
+    "Column", // actorname
     2028,   // doomednum
     S_COLU,   // spawnstate
     1000,   // spawnhealth
@@ -3677,6 +3759,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC32
+    "TallGreenColumn", // actorname
     30,   // doomednum
     S_TALLGRNCOL,   // spawnstate
     1000,   // spawnhealth
@@ -3707,6 +3790,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC33
+    "ShortGreenColumn", // actorname
     31,   // doomednum
     S_SHRTGRNCOL,   // spawnstate
     1000,   // spawnhealth
@@ -3737,6 +3821,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC34
+    "TallRedColumn", // actorname
     32,   // doomednum
     S_TALLREDCOL,   // spawnstate
     1000,   // spawnhealth
@@ -3767,6 +3852,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC35
+    "ShortRedColumn", // actorname
     33,   // doomednum
     S_SHRTREDCOL,   // spawnstate
     1000,   // spawnhealth
@@ -3797,6 +3883,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC36
+    "SkullColumn", // actorname
     37,   // doomednum
     S_SKULLCOL,   // spawnstate
     1000,   // spawnhealth
@@ -3827,6 +3914,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC37
+    "HeartColumn", // actorname
     36,   // doomednum
     S_HEARTCOL,   // spawnstate
     1000,   // spawnhealth
@@ -3857,6 +3945,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC38
+    "EvilEye", // actorname
     41,   // doomednum
     S_EVILEYE,    // spawnstate
     1000,   // spawnhealth
@@ -3887,6 +3976,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC39
+    "FloatingSkull", // actorname
     42,   // doomednum
     S_FLOATSKULL,   // spawnstate
     1000,   // spawnhealth
@@ -3917,6 +4007,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC40
+    "TorchTree", // actorname
     43,   // doomednum
     S_TORCHTREE,    // spawnstate
     1000,   // spawnhealth
@@ -3947,6 +4038,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC41
+    "BlueTorch", // actorname
     44,   // doomednum
     S_BLUETORCH,    // spawnstate
     1000,   // spawnhealth
@@ -3977,6 +4069,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC42
+    "GreenTorch", // actorname
     45,   // doomednum
     S_GREENTORCH,   // spawnstate
     1000,   // spawnhealth
@@ -4007,6 +4100,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC43
+    "RedTorch", // actorname
     46,   // doomednum
     S_REDTORCH,   // spawnstate
     1000,   // spawnhealth
@@ -4037,6 +4131,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC44
+    "ShortBlueTorch", // actorname
     55,   // doomednum
     S_BTORCHSHRT,   // spawnstate
     1000,   // spawnhealth
@@ -4067,6 +4162,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC45
+    "ShortGreenTorch", // actorname
     56,   // doomednum
     S_GTORCHSHRT,   // spawnstate
     1000,   // spawnhealth
@@ -4097,6 +4193,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC46
+    "ShortRedTorch", // actorname
     57,   // doomednum
     S_RTORCHSHRT,   // spawnstate
     1000,   // spawnhealth
@@ -4127,6 +4224,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC47
+    "Stalagtite", // actorname
     47,   // doomednum
     S_STALAGTITE,   // spawnstate
     1000,   // spawnhealth
@@ -4157,6 +4255,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC48
+    "TechPillar", // actorname
     48,   // doomednum
     S_TECHPILLAR,   // spawnstate
     1000,   // spawnhealth
@@ -4187,6 +4286,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC49
+    "CandleStick", // actorname
     34,   // doomednum
     S_CANDLESTIK,   // spawnstate
     1000,   // spawnhealth
@@ -4217,6 +4317,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC50
+    "Candelabra", // actorname
     35,   // doomednum
     S_CANDELABRA,   // spawnstate
     1000,   // spawnhealth
@@ -4247,6 +4348,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC51
+    "BloodyTwitch", // actorname
     49,   // doomednum
     S_BLOODYTWITCH,   // spawnstate
     1000,   // spawnhealth
@@ -4277,6 +4379,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC52
+    "Meat2", // actorname
     50,   // doomednum
     S_MEAT2,    // spawnstate
     1000,   // spawnhealth
@@ -4307,6 +4410,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC53
+    "Meat3", // actorname
     51,   // doomednum
     S_MEAT3,    // spawnstate
     1000,   // spawnhealth
@@ -4337,6 +4441,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC54
+    "Meat4", // actorname
     52,   // doomednum
     S_MEAT4,    // spawnstate
     1000,   // spawnhealth
@@ -4367,6 +4472,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC55
+    "Meat5", // actorname
     53,   // doomednum
     S_MEAT5,    // spawnstate
     1000,   // spawnhealth
@@ -4397,6 +4503,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC56
+    "NonsolidMeat2", // actorname
     59,   // doomednum
     S_MEAT2,    // spawnstate
     1000,   // spawnhealth
@@ -4427,6 +4534,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC57
+    "NonsolidMeat4", // actorname
     60,   // doomednum
     S_MEAT4,    // spawnstate
     1000,   // spawnhealth
@@ -4457,6 +4565,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC58
+    "NonsolidMeat3", // actorname
     61,   // doomednum
     S_MEAT3,    // spawnstate
     1000,   // spawnhealth
@@ -4487,6 +4596,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC59
+    "NonsolidMeat5", // actorname
     62,   // doomednum
     S_MEAT5,    // spawnstate
     1000,   // spawnhealth
@@ -4517,6 +4627,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC60
+    "NonsolidTwitch", // actorname
     63,   // doomednum
     S_BLOODYTWITCH,   // spawnstate
     1000,   // spawnhealth
@@ -4547,6 +4658,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC61
+    "DeadCacodemon", // actorname
     22,   // doomednum
     S_HEAD_DIE6,    // spawnstate
     1000,   // spawnhealth
@@ -4577,6 +4689,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC62
+    "DeadMarine", // actorname
     15,   // doomednum
     S_PLAY_DIE7,    // spawnstate
     1000,   // spawnhealth
@@ -4607,6 +4720,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC63
+    "DeadZombieMan", // actorname
     18,   // doomednum
     S_POSS_DIE5,    // spawnstate
     1000,   // spawnhealth
@@ -4637,6 +4751,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC64
+    "DeadDemon", // actorname
     21,   // doomednum
     S_SARG_DIE6,    // spawnstate
     1000,   // spawnhealth
@@ -4667,6 +4782,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC65
+    "DeadLostSoul", // actorname
     23,   // doomednum
     S_SKULL_DIE6,   // spawnstate
     1000,   // spawnhealth
@@ -4697,6 +4813,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC66
+    "DeadDoomImp", // actorname
     20,   // doomednum
     S_TROO_DIE5,    // spawnstate
     1000,   // spawnhealth
@@ -4727,6 +4844,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC67
+    "DeadShotgunGuy", // actorname
     19,   // doomednum
     S_SPOS_DIE5,    // spawnstate
     1000,   // spawnhealth
@@ -4757,6 +4875,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC68
+    "GibbedMarine", // actorname
     10,   // doomednum
     S_PLAY_XDIE9,   // spawnstate
     1000,   // spawnhealth
@@ -4787,6 +4906,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC69
+    "GibbedMarineExtra", // actorname
     12,   // doomednum
     S_PLAY_XDIE9,   // spawnstate
     1000,   // spawnhealth
@@ -4817,6 +4937,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC70
+    "HeadsOnAStick", // actorname
     28,   // doomednum
     S_HEADSONSTICK,   // spawnstate
     1000,   // spawnhealth
@@ -4847,6 +4968,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC71
+    "Gibs", // actorname
     24,   // doomednum
     S_GIBS,   // spawnstate
     1000,   // spawnhealth
@@ -4877,6 +4999,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC72
+    "HeadOnAStick", // actorname
     27,   // doomednum
     S_HEADONASTICK,   // spawnstate
     1000,   // spawnhealth
@@ -4907,6 +5030,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC73
+    "HeadCandles", // actorname
     29,   // doomednum
     S_HEADCANDLES,    // spawnstate
     1000,   // spawnhealth
@@ -4937,6 +5061,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC74
+    "DeadStick", // actorname
     25,   // doomednum
     S_DEADSTICK,    // spawnstate
     1000,   // spawnhealth
@@ -4967,6 +5092,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC75
+    "LiveStick", // actorname
     26,   // doomednum
     S_LIVESTICK,    // spawnstate
     1000,   // spawnhealth
@@ -4997,6 +5123,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC76
+    "BigTree", // actorname
     54,   // doomednum
     S_BIGTREE,    // spawnstate
     1000,   // spawnhealth
@@ -5027,6 +5154,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC77
+    "BurningBarrel", // actorname
     70,   // doomednum
     S_BBAR1,    // spawnstate
     1000,   // spawnhealth
@@ -5057,6 +5185,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC78
+    "HangNoGuts", // actorname
     73,   // doomednum
     S_HANGNOGUTS,   // spawnstate
     1000,   // spawnhealth
@@ -5087,6 +5216,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC79
+    "HangBNoBrain", // actorname
     74,   // doomednum
     S_HANGBNOBRAIN,   // spawnstate
     1000,   // spawnhealth
@@ -5117,6 +5247,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC80
+    "HangTLookingDown", // actorname
     75,   // doomednum
     S_HANGTLOOKDN,    // spawnstate
     1000,   // spawnhealth
@@ -5147,6 +5278,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC81
+    "HangTSkull", // actorname
     76,   // doomednum
     S_HANGTSKULL,   // spawnstate
     1000,   // spawnhealth
@@ -5177,6 +5309,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC82
+    "HangTLookingUp", // actorname
     77,   // doomednum
     S_HANGTLOOKUP,    // spawnstate
     1000,   // spawnhealth
@@ -5207,6 +5340,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC83
+    "HangTNoBrain", // actorname
     78,   // doomednum
     S_HANGTNOBRAIN,   // spawnstate
     1000,   // spawnhealth
@@ -5237,6 +5371,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC84
+    "ColonGibs", // actorname
     79,   // doomednum
     S_COLONGIBS,    // spawnstate
     1000,   // spawnhealth
@@ -5267,6 +5402,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC85
+    "SmallBloodPool", // actorname
     80,   // doomednum
     S_SMALLPOOL,    // spawnstate
     1000,   // spawnhealth
@@ -5297,6 +5433,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
   },
 
   {   // MT_MISC86
+    "BrainStem", // actorname
     81,   // doomednum
     S_BRAINSTEM,    // spawnstate
     1000,   // spawnhealth
@@ -5328,6 +5465,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 
   // For use with wind and current effects
   {   // MT_PUSH                       // phares
+    "PointPusher",  // actorname
     5001,           // doomednum       //   |      //jff 5/11/98 deconflict
     S_TNT1,         // spawnstate      //   V      // with DOSDoom
     1000,           // spawnhealth
@@ -5359,6 +5497,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 
   // For use with wind and current effects
   {   // MT_PULL
+    "PointPuller",  // actorname
     5002,           // doomednum                   //jff 5/11/98 deconflict
     S_TNT1,         // spawnstate                  // with DOSDoom
     1000,           // spawnhealth

--- a/src/info.h
+++ b/src/info.h
@@ -1440,6 +1440,7 @@ typedef enum {
 
 typedef struct
 {
+  const char * actorname; /* Doom actor name, meant to match ZDoom's */
   int doomednum;    /* Thing number used in id's editor, and now
        probably by every other editor too */
   int spawnstate;   /* The state (frame) index when this Thing is

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -666,7 +666,7 @@ void M_NewGame(int choice)
     return;
   }
 
-  if ( gamemode == commercial )
+  if ( EpiDef.numitems == 0 )
     M_SetupNextMenu(&NewDef);
   else
     M_SetupNextMenu(&EpiDef);
@@ -5416,6 +5416,7 @@ void M_Init(void)
       ReadDef1.x = 330;
       ReadDef1.y = 165;
       ReadMenu1[0].routine = M_FinishReadThis;
+      EpiDef.numitems = 0;
       break;
     case registered:
       // Episode 2 and 3 are handled,

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -515,8 +515,10 @@ menuitem_t EpisodeMenu[]=
   {1,"M_EPI3", M_Episode,'i',"Episode 3"},
   {1,"M_EPI4", M_Episode,'t',"Episode 4"},
   {1,"M_EPI5", M_Episode,'s',"Episode 5"},
+  // Some extra empty episodes for extensibility through UMAPINFO
   {1,"M_EPI6", M_Episode,'6',"Episode 6"},
-  {1,"M_EPI7", M_Episode,'7',"Episode 7"}
+  {1,"M_EPI7", M_Episode,'7',"Episode 7"},
+  {1,"M_EPI8", M_Episode,'8',"Episode 8"}
 };
 
 menu_t EpiDef =
@@ -529,10 +531,52 @@ menu_t EpiDef =
   0              // lastOn
 };
 
+// This is for customized episode menus
+int EpiCustom;
+short EpiMenuEpi[8], EpiMenuMap[8];
+
 //
 //    M_Episode
 //
 int epi;
+
+void M_AddEpisode(const char *map, char *def)
+{
+  if (!EpiCustom) {
+     EpiCustom = true;
+     // No more than 4 Eps expected when having UMAPINFO (prevent SIGILv1.2 from showing twice)
+     if (EpiDef.numitems > 4)
+        EpiDef.numitems = 4;
+  }
+  if (*def == '-')	// means 'clear'
+  {
+    EpiDef.numitems = 0;
+  }
+  else
+  {
+    const char *gfx = strtok(def, "\n");
+    const char *txt = strtok(NULL, "\n");
+    const char *alpha = strtok(NULL, "\n");
+    if (EpiDef.numitems >= 8) return;
+    int episodenum, mapnum;
+    G_ValidateMapName(map, &episodenum, &mapnum);
+    EpiMenuEpi[EpiDef.numitems] = episodenum;
+    EpiMenuMap[EpiDef.numitems] = mapnum;
+    strncpy(EpisodeMenu[EpiDef.numitems].name, gfx, 8);
+    EpisodeMenu[EpiDef.numitems].name[8] = 0;
+    EpisodeMenu[EpiDef.numitems].alttext = txt;
+    EpisodeMenu[EpiDef.numitems].alphaKey = alpha ? *alpha : 0;
+    EpiDef.numitems++;
+  }
+  if (EpiDef.numitems <= 4)
+  {
+    EpiDef.y = 63;
+  }
+  else
+  {
+    EpiDef.y = 63 - (EpiDef.numitems - 4) * (LINEHEIGHT / 2);
+  }
+}
 
 void M_DrawEpisode(void)
 {
@@ -646,7 +690,8 @@ void M_ChooseSkill(int choice)
       return;
     }
 
-  G_DeferedInitNew(choice,epi+1,1);
+  if (!EpiCustom) G_DeferedInitNew(choice,epi+1,1);
+  else G_DeferedInitNew(choice, EpiMenuEpi[epi], EpiMenuMap[epi]);
   M_ClearMenus ();
 }
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -29,7 +29,7 @@
  * DESCRIPTION:
  *  Main loop menu stuff.
  *  Default Config File.
- *  PCX Screenshots.
+ *  Auxiliary functions.
  *
  *-----------------------------------------------------------------------------*/
 
@@ -131,6 +131,19 @@ int M_ReadFile(char const *name, uint8_t **buffer)
     * because we could have a legit 0-length file. So make it -1. */
    return -1;
 }
+
+/*
+ * M_Strupr
+ *
+ * String to Uppercase
+ */
+char* M_Strupr(char* str)
+{
+  char* p;
+  for (p=str; *p; p++) *p = toupper(*p);
+  return str;
+}
+
 
 //
 // DEFAULTS

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -28,7 +28,7 @@
  *
  * DESCRIPTION:
  *  External non-system-specific stuff, like storing config settings,
- *  simple file handling, and saving screnshots.
+ *  simple file handling, and auxiliary string functions.
  *
  *-----------------------------------------------------------------------------*/
 
@@ -53,6 +53,8 @@ void M_LoadDefaults (void);
 void M_SaveDefaults (void);
 
 struct default_s *M_LookupDefault(const char *name);     /* killough 11/98 */
+
+char* M_Strupr(char* str);
 
 // phares 4/21/98:
 // Moved from m_misc.c so m_menu.c could see it.

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -224,7 +224,9 @@ void P_InitPicAnims (void)
     lastanim->speed = LONG(animdefs[i].speed); // killough 5/5/98: add LONG()
     lastanim++;
   }
-  W_UnlockLumpNum(lump);
+
+  if (lump != -1)
+    W_UnlockLumpNum(lump);
 }
 
 ///////////////////////////////////////////////////////////////

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -163,7 +163,9 @@ void P_InitSwitchList(void)
 
   numswitches = index/2;
   switchlist[index] = -1;
-  W_UnlockLumpNum(lump);
+
+  if (lump != -1)
+     W_UnlockLumpNum(lump);
 }
 
 //

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -132,6 +132,7 @@ musicinfo_t S_music[] = {
   { "read_m", 0, NULL, 0 },
   { "dm2ttl", 0, NULL, 0 },
   { "dm2int", 0, NULL, 0 },
+  { NULL,     0, NULL, 0 } // custom music
 };
 
 

--- a/src/u_mapinfo.c
+++ b/src/u_mapinfo.c
@@ -1,0 +1,528 @@
+//-----------------------------------------------------------------------------
+//
+// Copyright 2017 Christoph Oelckers
+// Copyright 2019 Fernando Carmona Varo
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+//
+//-----------------------------------------------------------------------------
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+
+#include "doomdef.h"
+#include "m_misc.h"
+#include "g_game.h"
+#include "u_scanner.h"
+
+#include "u_mapinfo.h"
+
+
+//==========================================================================
+//
+// The Doom actors in their original order
+// Names are the same as in ZDoom.
+//
+//==========================================================================
+
+static const int actornum = 144;
+static const char * const ActorNames[] =
+{
+  "DoomPlayer",
+  "ZombieMan",
+  "ShotgunGuy",
+  "Archvile",
+  "ArchvileFire",
+  "Revenant",
+  "RevenantTracer",
+  "RevenantTracerSmoke",
+  "Fatso",
+  "FatShot",
+  "ChaingunGuy",
+  "DoomImp",
+  "Demon",
+  "Spectre",
+  "Cacodemon",
+  "BaronOfHell",
+  "BaronBall",
+  "HellKnight",
+  "LostSoul",
+  "SpiderMastermind",
+  "Arachnotron",
+  "Cyberdemon",
+  "PainElemental",
+  "WolfensteinSS",
+  "CommanderKeen",
+  "BossBrain",
+  "BossEye",
+  "BossTarget",
+  "SpawnShot",
+  "SpawnFire",
+  "ExplosiveBarrel",
+  "DoomImpBall",
+  "CacodemonBall",
+  "Rocket",
+  "PlasmaBall",
+  "BFGBall",
+  "ArachnotronPlasma",
+  "BulletPuff",
+  "Blood",
+  "TeleportFog",
+  "ItemFog",
+  "TeleportDest",
+  "BFGExtra",
+  "GreenArmor",
+  "BlueArmor",
+  "HealthBonus",
+  "ArmorBonus",
+  "BlueCard",
+  "RedCard",
+  "YellowCard",
+  "YellowSkull",
+  "RedSkull",
+  "BlueSkull",
+  "Stimpack",
+  "Medikit",
+  "Soulsphere",
+  "InvulnerabilitySphere",
+  "Berserk",
+  "BlurSphere",
+  "RadSuit",
+  "Allmap",
+  "Infrared",
+  "Megasphere",
+  "Clip",
+  "ClipBox",
+  "RocketAmmo",
+  "RocketBox",
+  "Cell",
+  "CellPack",
+  "Shell",
+  "ShellBox",
+  "Backpack",
+  "BFG9000",
+  "Chaingun",
+  "Chainsaw",
+  "RocketLauncher",
+  "PlasmaRifle",
+  "Shotgun",
+  "SuperShotgun",
+  "TechLamp",
+  "TechLamp2",
+  "Column",
+  "TallGreenColumn",
+  "ShortGreenColumn",
+  "TallRedColumn",
+  "ShortRedColumn",
+  "SkullColumn",
+  "HeartColumn",
+  "EvilEye",
+  "FloatingSkull",
+  "TorchTree",
+  "BlueTorch",
+  "GreenTorch",
+  "RedTorch",
+  "ShortBlueTorch",
+  "ShortGreenTorch",
+  "ShortRedTorch",
+  "Slalagtite",
+  "TechPillar",
+  "CandleStick",
+  "Candelabra",
+  "BloodyTwitch",
+  "Meat2",
+  "Meat3",
+  "Meat4",
+  "Meat5",
+  "NonsolidMeat2",
+  "NonsolidMeat4",
+  "NonsolidMeat3",
+  "NonsolidMeat5",
+  "NonsolidTwitch",
+  "DeadCacodemon",
+  "DeadMarine",
+  "DeadZombieMan",
+  "DeadDemon",
+  "DeadLostSoul",
+  "DeadDoomImp",
+  "DeadShotgunGuy",
+  "GibbedMarine",
+  "GibbedMarineExtra",
+  "HeadsOnAStick",
+  "Gibs",
+  "HeadOnAStick",
+  "HeadCandles",
+  "DeadStick",
+  "LiveStick",
+  "BigTree",
+  "BurningBarrel",
+  "HangNoGuts",
+  "HangBNoBrain",
+  "HangTLookingDown",
+  "HangTSkull",
+  "HangTLookingUp",
+  "HangTNoBrain",
+  "ColonGibs",
+  "SmallBloodPool",
+  "BrainStem",
+  //Boom/MBF additions
+  "PointPusher",
+  "PointPuller",
+  "MBFHelperDog",
+  "PlasmaBall1",
+  "PlasmaBall2",
+  "EvilSceptre",
+  "UnholyBible",
+  NULL
+};
+
+
+void M_AddEpisode(const char *map, char *def);
+
+umapinfo_t U_mapinfo;
+
+// -----------------------------------------------
+//
+//
+// -----------------------------------------------
+
+static void FreeMap(mapentry_t *mape)
+{
+  if (mape->mapname) free(mape->mapname);
+  if (mape->levelname) free(mape->levelname);
+  if (mape->intertext) free(mape->intertext);
+  if (mape->intertextsecret) free(mape->intertextsecret);
+  mape->mapname = NULL;
+}
+
+static void ReplaceString(char **pptr, const char *newstring)
+{
+  if (*pptr != NULL) free(*pptr);
+  *pptr = strdup(newstring);
+}
+
+
+// -----------------------------------------------
+// Parses a set of string and concatenates them
+// Returns a pointer to the string (must be freed)
+// -----------------------------------------------
+static char *ParseMultiString(u_scanner_t* s, int error)
+{
+  char *build = NULL;
+
+  if (U_CheckToken(s, TK_Identifier))
+  {
+    if (!strcasecmp(s->string, "clear"))
+    {
+      return strdup("-"); // this was explicitly deleted to override the default.
+    }
+    else
+    {
+      U_Error(s, "Either 'clear' or string constant expected");
+    }
+  }
+
+  do
+  {
+    U_MustGetToken(s, TK_StringConst);
+    if (build == NULL) build = strdup(s->string);
+    else
+    {
+      size_t oldlen = strlen(build);
+      size_t newlen = oldlen + strlen(s->string) + 2;
+
+      build = (char*)realloc(build, newlen);
+      build[oldlen] = '\n';
+      strcpy(build + oldlen + 1, s->string);
+      build[newlen] = 0;
+    }
+  } while (U_CheckToken(s, ','));
+  return build;
+}
+
+
+// -----------------------------------------------
+// Parses a lump name. The buffer must be at least 9 characters.
+// -----------------------------------------------
+static int ParseLumpName(u_scanner_t* s, char *buffer)
+{
+  U_MustGetToken(s, TK_StringConst);
+  if (strlen(s->string) > 8)
+  {
+    U_Error(s, "String too long. Maximum size is 8 characters.");
+    return 0;
+  }
+  strncpy(buffer, s->string, 8);
+  buffer[8] = 0;
+  M_Strupr(buffer);
+  return 1;
+}
+
+
+// -----------------------------------------------
+// Parses a standard property that is already known
+// These do not get stored in the property list
+// but in dedicated struct member variables.
+// -----------------------------------------------
+static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
+{
+  U_MustGetToken(s, TK_Identifier);
+  char *pname = strdup(s->string);
+  U_MustGetToken(s, '=');
+
+  if (!strcasecmp(pname, "levelname"))
+  {
+    U_MustGetToken(s, TK_StringConst);
+    ReplaceString(&mape->levelname, s->string);
+  }
+  else if (!strcasecmp(pname, "episode"))
+  {
+    char *lname = ParseMultiString(s, 1);
+    if (!lname) return 0;
+    M_AddEpisode(mape->mapname, lname);
+  }
+  else if (!strcasecmp(pname, "next"))
+  {
+    ParseLumpName(s, mape->nextmap);
+    if (!G_ValidateMapName(mape->nextmap, NULL, NULL))
+    {
+      U_Error(s, "Invalid map name %s.", mape->nextmap);
+      return 0;
+    }
+  }
+  else if (!strcasecmp(pname, "nextsecret"))
+  {
+    ParseLumpName(s, mape->nextsecret);
+    if (!G_ValidateMapName(mape->nextsecret, NULL, NULL))
+    {
+      U_Error(s, "Invalid map name %s", mape->nextmap);
+      return 0;
+    }
+  }
+  else if (!strcasecmp(pname, "levelpic"))
+  {
+    ParseLumpName(s, mape->levelpic);
+  }
+  else if (!strcasecmp(pname, "skytexture"))
+  {
+    ParseLumpName(s, mape->skytexture);
+  }
+  else if (!strcasecmp(pname, "music"))
+  {
+    ParseLumpName(s, mape->music);
+  }
+  else if (!strcasecmp(pname, "endpic"))
+  {
+    ParseLumpName(s, mape->endpic);
+  }
+  else if (!strcasecmp(pname, "endcast"))
+  {
+    U_MustGetToken(s, TK_BoolConst);
+    if (s->boolean) strcpy(mape->endpic, "$CAST");
+    else strcpy(mape->endpic, "-");
+  }
+  else if (!strcasecmp(pname, "endbunny"))
+  {
+    U_MustGetToken(s, TK_BoolConst);
+    if (s->boolean) strcpy(mape->endpic, "$BUNNY");
+    else strcpy(mape->endpic, "-");
+  }
+  else if (!strcasecmp(pname, "endgame"))
+  {
+    U_MustGetToken(s, TK_BoolConst);
+    if (s->boolean) strcpy(mape->endpic, "!");
+    else strcpy(mape->endpic, "-");
+  }
+  else if (!strcasecmp(pname, "exitpic"))
+  {
+    ParseLumpName(s, mape->exitpic);
+  }
+  else if (!strcasecmp(pname, "enterpic"))
+  {
+    ParseLumpName(s, mape->enterpic);
+  }
+  else if (!strcasecmp(pname, "nointermission"))
+  {
+    U_MustGetToken(s, TK_BoolConst);
+    mape->nointermission = s->boolean;
+  }
+  else if (!strcasecmp(pname, "partime"))
+  {
+    U_MustGetInteger(s);
+    mape->partime = TICRATE * s->number;
+  }
+  else if (!strcasecmp(pname, "intertext"))
+  {
+    char *lname = ParseMultiString(s, 1);
+    if (!lname) return 0;
+    if (mape->intertext != NULL) free(mape->intertext);
+    mape->intertext = lname;
+  }
+  else if (!strcasecmp(pname, "intertextsecret"))
+  {
+    char *lname = ParseMultiString(s, 1);
+    if (!lname) return 0;
+    if (mape->intertextsecret != NULL) free(mape->intertextsecret);
+    mape->intertextsecret = lname;
+  }
+  else if (!strcasecmp(pname, "interbackdrop"))
+  {
+    ParseLumpName(s, mape->interbackdrop);
+  }
+  else if (!strcasecmp(pname, "intermusic"))
+  {
+    ParseLumpName(s, mape->intermusic);
+  }
+  else if (!strcasecmp(pname, "bossaction"))
+  {
+    U_MustGetToken(s, TK_Identifier);
+    int special, tag;
+    if (!strcasecmp(s->string, "clear"))
+    {
+      // mark level free of boss actions
+      special = tag = -1;
+      if (mape->bossactions) free(mape->bossactions);
+      mape->bossactions = NULL;
+      mape->numbossactions = -1;
+    }
+    else
+    {
+      int i;
+      for (i = 0; i < actornum; i++)
+      {
+        if (!strcasecmp(s->string, ActorNames[i])) break;
+      }
+      if (ActorNames[i] == NULL)
+      {
+        U_Error(s, "Unknown thing type %s", s->string);
+        return 0;
+      }
+
+      U_MustGetToken(s, ',');
+      U_MustGetInteger(s);
+      special = s->number;
+      U_MustGetToken(s, ',');
+      U_MustGetInteger(s);
+      tag = s->number;
+      // allow no 0-tag specials here, unless a level exit.
+      if (tag != 0 || special == 11 || special == 51 || special == 52 || special == 124)
+      {
+        if (mape->numbossactions == -1) mape->numbossactions = 1;
+        else mape->numbossactions++;
+        mape->bossactions = (bossaction_t *)realloc(mape->bossactions, sizeof(bossaction_t) * mape->numbossactions);
+        mape->bossactions[mape->numbossactions - 1].type = i;
+        mape->bossactions[mape->numbossactions - 1].special = special;
+        mape->bossactions[mape->numbossactions - 1].tag = tag;
+      }
+    }
+  }
+  else do
+  {
+    if (!U_CheckFloat(s)) U_GetNextToken(s, TRUE);
+    if (s->token > TK_BoolConst)
+    {
+      U_ErrorToken(s, TK_Identifier);
+    }
+  } while (U_CheckToken(s, ','));
+
+  free(pname);
+  return 1;
+}
+
+// -----------------------------------------------
+//
+// Parses a complete map entry
+//
+// -----------------------------------------------
+
+static int ParseMapEntry(u_scanner_t *s, mapentry_t *val)
+{
+  val->mapname = NULL;
+
+  U_MustGetIdentifier(s, "map");
+  U_MustGetToken(s, TK_Identifier);
+
+  if (!G_ValidateMapName(s->string, NULL, NULL))
+  {
+    U_Error(s, "Invalid map name %s", s->string);
+    return 0;
+  }
+
+  ReplaceString(&val->mapname, s->string);
+  U_MustGetToken(s, '{');
+  while(!U_CheckToken(s, '}'))
+  {
+    ParseStandardProperty(s, val);
+  }
+  return 1;
+}
+
+
+// -----------------------------------------------
+//
+// Parses a complete UMAPINFO lump
+//
+// -----------------------------------------------
+
+int U_ParseMapInfo(const char *buffer, size_t length)
+{
+  unsigned int i;
+  u_scanner_t scanner = U_ScanOpen(buffer, length);
+
+  while (U_HasTokensLeft(&scanner))
+  {
+    mapentry_t parsed = { 0 };
+    if (!ParseMapEntry(&scanner, &parsed))
+    {
+      U_Error(&scanner, "Skipping entry: %s", scanner.string);
+    }
+
+    // Does this property already exist? If yes, replace it.
+    for(i = 0; i < U_mapinfo.mapcount; i++)
+    {
+      if (!strcmp(parsed.mapname, U_mapinfo.maps[i].mapname))
+      {
+        FreeMap(&U_mapinfo.maps[i]);
+        U_mapinfo.maps[i] = parsed;
+        break;
+      }
+    }
+    // Not found so create a new one.
+    if (i == U_mapinfo.mapcount)
+    {
+      U_mapinfo.mapcount++;
+      U_mapinfo.maps = (mapentry_t*)realloc(U_mapinfo.maps, sizeof(mapentry_t)*U_mapinfo.mapcount);
+      U_mapinfo.maps[U_mapinfo.mapcount-1] = parsed;
+    }
+  }
+  U_ScanClose(&scanner);
+  return 1;
+}
+
+
+
+void U_FreeMapInfo()
+{
+  unsigned i;
+
+  for(i = 0; i < U_mapinfo.mapcount; i++)
+  {
+    FreeMap(&U_mapinfo.maps[i]);
+  }
+  free(U_mapinfo.maps);
+  U_mapinfo.maps = NULL;
+  U_mapinfo.mapcount = 0;
+}

--- a/src/u_mapinfo.h
+++ b/src/u_mapinfo.h
@@ -1,0 +1,65 @@
+//-----------------------------------------------------------------------------
+//
+// Copyright 2017 Christoph Oelckers
+// Copyright 2019 Fernando Carmona Varo
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+//
+//-----------------------------------------------------------------------------
+
+#ifndef __UMAPINFO_H
+#define __UMAPINFO_H
+
+typedef struct
+{
+  int type;
+  int special;
+  int tag;
+} bossaction_t;
+
+typedef struct
+{
+  char *mapname;
+  char *levelname;
+  char *intertext;
+  char *intertextsecret;
+  char levelpic[9];
+  char nextmap[9];
+  char nextsecret[9];
+  char music[9];
+  char skytexture[9];
+  char endpic[9];
+  char exitpic[9];
+  char enterpic[9];
+  char interbackdrop[9];
+  char intermusic[9];
+  int partime;
+  int nointermission;
+  int numbossactions;
+  bossaction_t *bossactions;
+
+} mapentry_t;
+
+typedef struct
+{
+  unsigned int mapcount;
+  mapentry_t *maps;
+} umapinfo_t;
+
+extern umapinfo_t U_mapinfo;
+
+int U_ParseMapInfo(const char *buffer, size_t length);
+void U_FreeMapInfo();
+
+#endif

--- a/src/u_scanner.c
+++ b/src/u_scanner.c
@@ -1,0 +1,708 @@
+// Copyright (c) 2019, Fernando Carmona Varo  <ferkiwi@gmail.com>
+// Copyright (c) 2010, Braden "Blzut3" Obrzut <admin@maniacsvault.net>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//    * Neither the name of the <organization> nor the
+//      names of its contributors may be used to endorse or promote products
+//      derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <stdarg.h>
+#include <ctype.h>
+
+#include "doomtype.h"
+#include "z_zone.h"
+#include "lprintf.h"
+#include "u_scanner.h"
+
+const char* U_TokenNames[TK_NumSpecialTokens] =
+{
+  "Identifier", // case insensitive identifier, beginning with a letter and may contain [a-z0-9_]
+  "String Constant",
+  "Integer Constant",
+  "Float Constant",
+  "Boolean Constant",
+  "Logical And",
+  "Logical Or",
+  "Equals",
+  "Not Equals",
+  "Greater Than or Equals"
+  "Less Than or Equals",
+  "Left Shift",
+  "Right Shift"
+};
+
+void U_CheckForWhitespace(u_scanner_t* scanner);
+void U_ExpandState(u_scanner_t* scanner);
+void U_Unescape(char *str);
+void U_SetString(char **ptr, const char *start, int length);
+
+u_scanner_t U_ScanOpen(const char* data, int length)
+{
+  u_scanner_t scanner;
+  scanner.lineStart = scanner.logicalPosition = scanner.scanPos = scanner.tokenLinePosition = 0;
+  scanner.line = scanner.tokenLine = 1;
+  scanner.needNext = TRUE;
+  scanner.string = NULL;
+  scanner.nextState.string = NULL;
+
+  if(length == -1)
+    length = strlen(data);
+  scanner.length = length;
+  scanner.data = (char*) malloc(sizeof(char)*length);
+  memcpy(scanner.data, data, length);
+
+  U_CheckForWhitespace(&scanner);
+
+  return scanner;
+}
+
+void U_ScanClose(u_scanner_t* scanner)
+{
+  if (scanner->nextState.string != NULL)
+    free(scanner->nextState.string);
+  if(scanner->data != NULL)
+    free(scanner->data);
+}
+
+void U_IncrementLine(u_scanner_t* scanner)
+{
+  scanner->line++;
+  scanner->lineStart = scanner->scanPos;
+}
+
+void U_CheckForWhitespace(u_scanner_t* scanner)
+{
+  int comment = 0; // 1 = till next new line, 2 = till end block
+  while(scanner->scanPos < scanner->length)
+  {
+    char cur = scanner->data[scanner->scanPos];
+    char next = scanner->scanPos+1 < scanner->length ? scanner->data[scanner->scanPos+1] : 0;
+    if(comment == 2)
+    {
+      if(cur != '*' || next != '/')
+      {
+        if(cur == '\n' || cur == '\r')
+        {
+          scanner->scanPos++;
+
+          // Do a quick check for Windows style new line
+          if(cur == '\r' && next == '\n')
+            scanner->scanPos++;
+          U_IncrementLine(scanner);
+        }
+        else
+          scanner->scanPos++;
+      }
+      else
+      {
+        comment = 0;
+        scanner->scanPos += 2;
+      }
+      continue;
+    }
+
+    if(cur == ' ' || cur == '\t' || cur == 0)
+      scanner->scanPos++;
+    else if(cur == '\n' || cur == '\r')
+    {
+      scanner->scanPos++;
+      if(comment == 1)
+        comment = 0;
+
+      // Do a quick check for Windows style new line
+      if(cur == '\r' && next == '\n')
+        scanner->scanPos++;
+      U_IncrementLine(scanner);
+    }
+    else if(cur == '/' && comment == 0)
+    {
+      switch(next)
+      {
+        case '/':
+          comment = 1;
+          break;
+        case '*':
+          comment = 2;
+          break;
+        default:
+          return;
+      }
+      scanner->scanPos += 2;
+    }
+    else
+    {
+      if(comment == 0)
+        return;
+      else
+        scanner->scanPos++;
+    }
+  }
+}
+
+boolean U_CheckToken(u_scanner_t* s, char token)
+{
+  if(s->needNext)
+  {
+    if(!U_GetNextToken(s, FALSE))
+    return FALSE;
+  }
+
+  // An int can also be a float.
+  if((s->nextState).token == token || ((s->nextState).token == TK_IntConst && s->token == TK_FloatConst))
+  {
+    s->needNext = TRUE;
+    U_ExpandState(s);
+    return TRUE;
+  }
+  s->needNext = FALSE;
+  return FALSE;
+}
+
+void U_ExpandState(u_scanner_t* s)
+{
+  s->logicalPosition = s->scanPos;
+  U_CheckForWhitespace(s);
+
+  U_SetString(&(s->string), s->nextState.string, -1);
+  s->number = s->nextState.number;
+  s->decimal = s->nextState.decimal;
+  s->boolean = s->nextState.boolean;
+  s->token = s->nextState.token;
+  s->tokenLine = s->nextState.tokenLine;
+  s->tokenLinePosition = s->nextState.tokenLinePosition;
+}
+
+void U_SaveState(u_scanner_t* s, u_scanner_t savedstate)
+{
+  // This saves the entire parser state except for the data pointer.
+  if (savedstate.string != NULL) free(savedstate.string);
+  if (savedstate.nextState.string != NULL) free(savedstate.nextState.string);
+
+  memcpy(&savedstate, s, sizeof(*s));
+  savedstate.string = strdup(s->string);
+  savedstate.nextState.string = strdup(s->nextState.string);
+  savedstate.data = NULL;
+}
+
+void U_RestoreState(u_scanner_t* s, u_scanner_t savedstate)
+{
+  if (savedstate.data == NULL)
+  {
+    char *saveddata = s->data;
+    U_SaveState(&savedstate, *s);
+    s->data = saveddata;
+  }
+}
+
+boolean U_GetNextToken(u_scanner_t* scanner, boolean expandState)
+{
+  u_parserstate_t* nextState = &scanner->nextState;
+
+  if(!scanner->needNext)
+  {
+    scanner->needNext = TRUE;
+    if(expandState)
+      U_ExpandState(scanner);
+    return TRUE;
+  }
+
+  nextState->tokenLine = scanner->line;
+  nextState->tokenLinePosition = scanner->scanPos - scanner->lineStart;
+  nextState->token = TK_NoToken;
+  if(scanner->scanPos >= scanner->length)
+  {
+    if(expandState)
+      U_ExpandState(scanner);
+    return FALSE;
+  }
+
+  unsigned int start = scanner->scanPos;
+  unsigned int end = scanner->scanPos;
+  int integerBase = 10;
+  boolean floatHasDecimal = FALSE;
+  boolean floatHasExponent = FALSE;
+  boolean stringFinished = FALSE; // Strings are the only things that can have 0 length tokens.
+
+  char cur = scanner->data[scanner->scanPos++];
+
+  // Determine by first character
+  if(cur == '_' || (cur >= 'A' && cur <= 'Z') || (cur >= 'a' && cur <= 'z'))
+    nextState->token = TK_Identifier;
+  else if(cur >= '0' && cur <= '9')
+  {
+    if(cur == '0')
+      integerBase = 8;
+    nextState->token = TK_IntConst;
+  }
+  else if(cur == '.')
+  {
+    floatHasDecimal = TRUE;
+    nextState->token = TK_FloatConst;
+  }
+  else if(cur == '"')
+  {
+    end = ++start; // Move the start up one character so we don't have to trim it later.
+    nextState->token = TK_StringConst;
+  }
+  else
+  {
+    end = scanner->scanPos;
+    nextState->token = cur;
+
+    // Now check for operator tokens
+    if(scanner->scanPos < scanner->length)
+    {
+      char next = scanner->data[scanner->scanPos];
+      if(cur == '&' && next == '&')
+        nextState->token = TK_AndAnd;
+      else if(cur == '|' && next == '|')
+        nextState->token = TK_OrOr;
+      else if(cur == '<' && next == '<')
+        nextState->token = TK_ShiftLeft;
+      else if(cur == '>' && next == '>')
+        nextState->token = TK_ShiftRight;
+      //else if(cur == '#' && next == '#')
+      //  nextState.token = TK_MacroConcat;
+      else if(next == '=')
+      {
+        switch(cur)
+        {
+          case '=':
+            nextState->token = TK_EqEq;
+            break;
+          case '!':
+            nextState->token = TK_NotEq;
+            break;
+          case '>':
+            nextState->token = TK_GtrEq;
+            break;
+          case '<':
+            nextState->token = TK_LessEq;
+            break;
+          default:
+            break;
+        }
+      }
+      if(nextState->token != cur)
+      {
+        scanner->scanPos++;
+        end = scanner->scanPos;
+      }
+    }
+  }
+
+  if(start == end)
+  {
+    while(scanner->scanPos < scanner->length)
+    {
+      cur = scanner->data[scanner->scanPos];
+      switch(nextState->token)
+      {
+        default:
+          break;
+        case TK_Identifier:
+          if(cur != '_' && (cur < 'A' || cur > 'Z') && (cur < 'a' || cur > 'z') && (cur < '0' || cur > '9'))
+            end = scanner->scanPos;
+          break;
+        case TK_IntConst:
+          if(cur == '.' || (scanner->scanPos-1 != start && cur == 'e'))
+            nextState->token = TK_FloatConst;
+          else if((cur == 'x' || cur == 'X') && scanner->scanPos-1 == start)
+          {
+            integerBase = 16;
+            break;
+          }
+          else
+          {
+            switch(integerBase)
+            {
+              default:
+                if(cur < '0' || cur > '9')
+                  end = scanner->scanPos;
+                break;
+              case 8:
+                if(cur < '0' || cur > '7')
+                  end = scanner->scanPos;
+                break;
+              case 16:
+                if((cur < '0' || cur > '9') && (cur < 'A' || cur > 'F') && (cur < 'a' || cur > 'f'))
+                  end = scanner->scanPos;
+                break;
+            }
+            break;
+          }
+        case TK_FloatConst:
+          if(cur < '0' || cur > '9')
+          {
+            if(!floatHasDecimal && cur == '.')
+            {
+              floatHasDecimal = TRUE;
+              break;
+            }
+            else if(!floatHasExponent && cur == 'e')
+            {
+              floatHasDecimal = TRUE;
+              floatHasExponent = TRUE;
+              if(scanner->scanPos+1 < scanner->length)
+              {
+                char next = scanner->data[scanner->scanPos+1];
+                if((next < '0' || next > '9') && next != '+' && next != '-')
+                  end = scanner->scanPos;
+                else
+                  scanner->scanPos++;
+              }
+              break;
+            }
+            end = scanner->scanPos;
+          }
+          break;
+        case TK_StringConst:
+          if(cur == '"')
+          {
+            stringFinished = TRUE;
+            end = scanner->scanPos;
+            scanner->scanPos++;
+          }
+          else if(cur == '\\')
+            scanner->scanPos++; // Will add two since the loop automatically adds one
+          break;
+      }
+      if(start == end && !stringFinished)
+        scanner->scanPos++;
+      else
+        break;
+    }
+  }
+
+  if(end-start > 0 || stringFinished)
+  {
+    U_SetString(&(nextState->string), scanner->data+start, end-start);
+    if(nextState->token == TK_FloatConst)
+    {
+      nextState->decimal = atof(nextState->string);
+      nextState->number = (int) (nextState->decimal);
+      nextState->boolean = (nextState->number != 0);
+    }
+    else if(nextState->token == TK_IntConst)
+    {
+      nextState->number = strtol(nextState->string, NULL, integerBase);
+      nextState->decimal = nextState->number;
+      nextState->boolean = (nextState->number != 0);
+    }
+    else if(nextState->token == TK_Identifier)
+    {
+      // Identifiers should be case insensitive.
+      char *p = nextState->string;
+      while (*p)
+      {
+        *p = tolower(*p);
+        p++;
+      }
+      // Check for a boolean constant.
+      if(strcmp(nextState->string, "true") == 0)
+      {
+        nextState->token = TK_BoolConst;
+        nextState->boolean = TRUE;
+      }
+      else if (strcmp(nextState->string, "false") == 0)
+      {
+        nextState->token = TK_BoolConst;
+        nextState->boolean = FALSE;
+      }
+    }
+    else if(nextState->token == TK_StringConst)
+    {
+      U_Unescape(nextState->string);
+    }
+    if(expandState)
+      U_ExpandState(scanner);
+    return TRUE;
+  }
+  nextState->token = TK_NoToken;
+  if(expandState)
+    U_ExpandState(scanner);
+  return FALSE;
+}
+
+
+void U_ErrorToken(u_scanner_t* s, int token)
+{
+  if (token < TK_NumSpecialTokens && s->token < TK_NumSpecialTokens)
+    U_Error(s, "Expected %s but got %s '%s' instead.", U_TokenNames[token], U_TokenNames[(int)s->token], s->string);
+  else if (token < TK_NumSpecialTokens && s->token >= TK_NumSpecialTokens)
+    U_Error(s, "Expected %s but got '%c' instead.", U_TokenNames[token], s->token);
+  else if (token >= TK_NumSpecialTokens && s->token < TK_NumSpecialTokens)
+    U_Error(s, "Expected '%c' but got '%s' instead.", token, U_TokenNames[(int)s->token]);
+  else
+    U_Error(s, "Expected '%c' but got '%c' instead.", token, s->token);
+}
+
+void U_ErrorString(u_scanner_t* s, const char *mustget)
+{
+  if (s->token < TK_NumSpecialTokens)
+    U_Error(s, "Expected '%s' but got %s '%s' instead.", mustget, U_TokenNames[(int)s->token], s->string);
+  else
+    U_Error(s, "Expected '%s' but got '%c' instead.", mustget, s->token);
+}
+
+void U_Error(u_scanner_t* s, const char *msg, ...)
+{
+  char buffer[1024];
+  va_list ap;
+  va_start(ap, msg);
+  vsnprintf(buffer, 1024, msg, ap);
+  va_end(ap);
+  I_Error("%d:%d:%s.", s->tokenLine, s->tokenLinePosition, buffer);
+}
+
+boolean U_MustGetToken(u_scanner_t* s, char token)
+{
+  if(!U_CheckToken(s, token))
+  {
+    U_ExpandState(s);
+    U_ErrorToken(s, token);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+boolean U_MustGetIdentifier(u_scanner_t* s, const char *ident)
+{
+  if (!U_CheckToken(s, TK_Identifier) || strcasecmp(s->string, ident))
+  {
+    U_ErrorString(s, ident);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+// Convenience helpers that parse an entire number including a leading minus or plus sign
+boolean U_ScanInteger(u_scanner_t* s)
+{
+  boolean neg = FALSE;
+  if (!U_GetNextToken(s, TRUE))
+  {
+    return FALSE;
+  }
+  if (s->token == '-')
+  {
+   if (!U_GetNextToken(s, TRUE))
+    {
+      return FALSE;
+    }
+    neg = TRUE;
+  }
+  else if (s->token == '+')
+  {
+   if (!U_GetNextToken(s, TRUE))
+   {
+     return FALSE;
+   }
+  }
+  if (s->token != TK_IntConst)
+  {
+    return FALSE;
+  }
+  if (neg)
+  {
+    s->number = -(s->number);
+    s->decimal = -(s->decimal);
+  }
+  return TRUE;
+}
+
+boolean U_ScanFloat(u_scanner_t* s)
+{
+  boolean neg = FALSE;
+  if (!U_GetNextToken(s, TRUE))
+  {
+    return FALSE;
+  }
+  if (s->token == '-')
+  {
+    if (!U_GetNextToken(s, TRUE))
+    {
+      return FALSE;
+    }
+    neg = TRUE;
+  }
+  else if (s->token == '+')
+  {
+    if (!U_GetNextToken(s, TRUE))
+    {
+      return FALSE;
+    }
+  }
+  if (s->token != TK_IntConst && s->token != TK_FloatConst)
+  {
+    return FALSE;
+  }
+  if (neg)
+  {
+    s->number = -(s->number);
+    s->decimal = -(s->decimal);
+  }
+  return TRUE;
+}
+
+boolean U_CheckInteger(u_scanner_t* s)
+{
+  u_scanner_t savedstate;
+  U_SaveState(s, savedstate);
+  boolean res = U_ScanInteger(s);
+  if (!res) U_RestoreState(s, savedstate);
+  return res;
+}
+
+boolean U_CheckFloat(u_scanner_t* s)
+{
+  u_scanner_t savedstate;
+  U_SaveState(s, savedstate);
+  boolean res = U_ScanFloat(s);
+  if (!res) U_RestoreState(s, savedstate);
+  return res;
+}
+
+boolean U_MustGetInteger(u_scanner_t* s)
+{
+  if (!U_ScanInteger(s))
+  {
+    U_ErrorToken(s, TK_IntConst);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+boolean U_MustGetFloat(u_scanner_t* s)
+{
+  if (!U_ScanFloat(s))
+  {
+    U_ErrorToken(s, TK_FloatConst);
+    return FALSE;
+  }
+  return TRUE;
+}
+
+
+boolean U_HasTokensLeft(u_scanner_t* s)
+{
+  return (s->scanPos < s->length);
+}
+
+// This is taken from ZDoom's strbin function which can do a lot more than just unescaping backslashes and quotation marks.
+void U_Unescape(char *str)
+{
+  char *p = str, c;
+  int i;
+
+  while ((c = *p++)) {
+    if (c != '\\') {
+      *str++ = c;
+    }
+    else {
+      switch (*p) {
+      case 'a':
+        *str++ = '\a';
+        break;
+      case 'b':
+        *str++ = '\b';
+        break;
+      case 'f':
+        *str++ = '\f';
+        break;
+      case 'n':
+        *str++ = '\n';
+        break;
+      case 't':
+        *str++ = '\t';
+        break;
+      case 'r':
+        *str++ = '\r';
+        break;
+      case 'v':
+        *str++ = '\v';
+        break;
+      case '?':
+        *str++ = '\?';
+        break;
+      case '\n':
+        break;
+      case 'x':
+      case 'X':
+        c = 0;
+        for (i = 0; i < 2; i++)
+        {
+          p++;
+          if (*p >= '0' && *p <= '9')
+            c = (c << 4) + *p - '0';
+          else if (*p >= 'a' && *p <= 'f')
+            c = (c << 4) + 10 + *p - 'a';
+          else if (*p >= 'A' && *p <= 'F')
+            c = (c << 4) + 10 + *p - 'A';
+          else
+          {
+            p--;
+            break;
+          }
+        }
+        *str++ = c;
+        break;
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+        c = *p - '0';
+        for (i = 0; i < 2; i++)
+        {
+          p++;
+          if (*p >= '0' && *p <= '7')
+            c = (c << 3) + *p - '0';
+          else
+          {
+            p--;
+            break;
+          }
+        }
+        *str++ = c;
+        break;
+      default:
+        *str++ = *p;
+        break;
+      }
+      p++;
+    }
+  }
+  *str = 0;
+}
+
+void U_SetString(char **ptr, const char *start, int length)
+{
+  if (length == -1)
+    length = strlen(start);
+  if (*ptr != NULL) free(*ptr);
+  *ptr = (char*)malloc(length + 1);
+  memcpy(*ptr, start, length);
+  (*ptr)[length] = '\0';
+}

--- a/src/u_scanner.h
+++ b/src/u_scanner.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2010, Braden "Blzut3" Obrzut <admin@maniacsvault.net>
+// Copyright (c) 2019, Fernando Carmona Varo  <ferkiwi@gmail.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//    * Neither the name of the <organization> nor the
+//      names of its contributors may be used to endorse or promote products
+//      derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef __U_SCANNER_H__
+#define __U_SCANNER_H__
+
+#include "doomtype.h"
+
+enum
+{
+  TK_Identifier,  // Ex: SomeIdentifier
+  TK_StringConst,  // Ex: "Some String"
+  TK_IntConst,  // Ex: 27
+  TK_FloatConst,  // Ex: 1.5
+  TK_BoolConst,  // Ex: true
+  TK_AndAnd,    // &&
+  TK_OrOr,    // ||
+  TK_EqEq,    // ==
+  TK_NotEq,    // !=
+  TK_GtrEq,    // >=
+  TK_LessEq,    // <=
+  TK_ShiftLeft,  // <<
+  TK_ShiftRight,  // >>
+
+  TK_NumSpecialTokens,
+
+  TK_NoToken = -1
+};
+
+typedef struct
+{
+  char          *string;
+  int            number;
+  double        decimal;
+  boolean        boolean;
+  char          token;
+  unsigned int  tokenLine;
+  unsigned int  tokenLinePosition;
+} u_parserstate_t;
+
+typedef struct
+{
+  u_parserstate_t  nextState;
+
+  char*             data;
+  unsigned int     length;
+
+  unsigned int     line;
+  unsigned int     lineStart;
+  unsigned int     logicalPosition;
+  unsigned int     tokenLine;
+  unsigned int     tokenLinePosition;
+  unsigned int     scanPos;
+
+  boolean          needNext; // If checkToken returns false this will be false.
+
+  char*   string;
+  int     number;
+  double  decimal;
+  boolean boolean;
+  char    token;
+
+} u_scanner_t;
+
+
+u_scanner_t  U_ScanOpen(const char* data, int length);
+void         U_ScanClose(u_scanner_t* scanner);
+boolean      U_GetNextToken(u_scanner_t* scanner, boolean expandState);
+boolean      U_HasTokensLeft(u_scanner_t* scanner);
+boolean      U_MustGetToken(u_scanner_t* scanner, char token);
+boolean      U_MustGetIdentifier(u_scanner_t* scanner, const char *ident);
+boolean      U_MustGetInteger(u_scanner_t* s);
+boolean      U_MustGetFloat(u_scanner_t* s);
+boolean      U_CheckToken(u_scanner_t* scanner, char token);
+boolean      U_CheckInteger(u_scanner_t* s);
+boolean      U_CheckFloat(u_scanner_t* s);
+
+void         U_Error(u_scanner_t* s, const char *msg, ...);
+void         U_ErrorToken(u_scanner_t* s, int token);
+void         U_ErrorString(u_scanner_t* s, const char *mustget);
+
+#endif /* __U_SCANNER_H__ */

--- a/src/w_memcache.c
+++ b/src/w_memcache.c
@@ -103,6 +103,10 @@ const void *W_LockLumpNum(int lump)
 void W_UnlockLumpNum(int lump)
 {
   const int unlocks = 1;
+
+  // invalid lump, ignore unlock
+  if (lump < 0) return;
+
   cachelump[lump].locks -= unlocks;
   /* cph - Note: must only tell z_zone to make purgeable if currently locked,
    * else it might already have been purged

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -307,6 +307,7 @@ static void W_CoalesceMarkedResource(const char *start_marker,
 unsigned W_LumpNameHash(const char *s)
 {
   unsigned hash;
+  if (!s[0]) return 0;
   (void) ((hash =        toupper(s[0]), s[1]) &&
           (hash = hash*3+toupper(s[1]), s[2]) &&
           (hash = hash*2+toupper(s[2]), s[3]) &&

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -294,7 +294,15 @@ void *Z_Realloc(void *ptr, size_t n, int tag, void **user)
    if (ptr)
    {
       memblock_t *block = (memblock_t *)((uint8_t*) ptr - HEADER_SIZE);
-      memcpy(p, ptr, n <= block->size ? n : block->size);
+
+      if (n <= block->size)
+        memcpy(p, ptr, n);
+      else
+      {
+        memcpy(p, ptr, block->size);
+        memset(p+block->size, 0, n - block->size);
+      }
+
       (Z_Free)(ptr DA(file, line));
       if (user) // in case Z_Free nullified same user
          *user=p;


### PR DESCRIPTION
Implements support for the [new UMAPINFO lump](https://www.doomworld.com/forum/topic/93793-umapinfo-discussion/), which allows configuring
new episodes, intermission texts, secret levels and map properties.
It's a "lite" version of ZMAPINFO from ZDoom or EMAPINFO from eternity meant to be a common ground standard that works in closer-to-vanilla ports like Prboom.

This is based on prboom-plus UMAPINFO fork: https://github.com/coelckers/prboom-plus/tree/UMAPINFO-only

There isn't a lot of wads using this standard at the moment (so far I think only [Fork in the road](https://www.doomworld.com/forum/topic/107191-fork-in-the-road-a-umapinfo-project-2019-07-03-update-alpha-3/) and SIGIL v1.2+), but I think this will be a good thing to have so that there's even an option to have custom episodes that aren't hardcoded (like SIGIL pre-v1.2 was), and it'd probably make support for things like NERVE.wad and WolfenDoom with custom secret levels easier to support (this PR won't fix #106 by itself, but at least it'd be possible to use a custom WAD to load an UMAPINFO).

I've also sneaked in some commits to fix a few more potential memory issues that I found while testing.