### PR TITLE
Some Fixes to improve UMAPINFO support

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1420,6 +1420,7 @@ bool D_DoomMainSetup(void)
   {
     for (p = -1; (p = W_ListNumFromName("UMAPINFO", p)) >= 0; )
     {
+      lprintf(LO_INFO,"U_ParseMapInfo: Loading Custom Episode and Map Information.\n");
       const char *data = (const char *)W_CacheLumpNum(p);
       U_ParseMapInfo(data, W_LumpLength(p));
     }

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -295,9 +295,8 @@ void F_Ticker(void)
           if (!strcasecmp(gamemapinfo->endpic, "$CAST"))
           {
             F_StartCast();
-            //using_FMI = false;
-           }
-           else
+          }
+          else
           {
             FinaleCount = 0;
             FinaleStage = 1;
@@ -305,7 +304,6 @@ void F_Ticker(void)
             if (!strcasecmp(gamemapinfo->endpic, "$BUNNY"))
             {
               S_StartMusic(mus_bunny);
-              //using_FMI = false;
             }
           }
         }
@@ -453,14 +451,22 @@ void F_CastTicker (void)
   if (caststate->tics == -1 || caststate->nextstate == S_NULL)
   {
     // switch from deathstate to next monster
-    castnum++;
     castdeath = FALSE;
-    if (castorder[castnum].name == NULL)
-      castnum = 0;
-    if (mobjinfo[castorder[castnum].type].seesound)
-      S_StartSound (NULL, mobjinfo[castorder[castnum].type].seesound);
-    caststate = &states[mobjinfo[castorder[castnum].type].seestate];
     castframes = 0;
+
+    // find the next cast member with valid sprite frames
+    do
+    {
+       castnum++;
+       if (castorder[castnum].name == NULL)
+          castnum = 0;
+       caststate = &states[mobjinfo[castorder[castnum].type].seestate];
+    }
+    while(!sprites[caststate->sprite].numframes && castorder[castnum].name && castnum);
+
+    // Play its see sound
+    if (mobjinfo[castorder[castnum].type].seesound)
+       S_StartSound (NULL, mobjinfo[castorder[castnum].type].seesound);
   }
   else
   {
@@ -629,6 +635,7 @@ void F_CastDrawer (void)
 {
   spritedef_t*        sprdef;
   spriteframe_t*      sprframe;
+  int                 sprframenum;
   int                 lump;
   boolean             flip;
 
@@ -640,13 +647,17 @@ void F_CastDrawer (void)
 
   // draw the current frame in the middle of the screen
   sprdef = &sprites[caststate->sprite];
-  sprframe = &sprdef->spriteframes[ caststate->frame & FF_FRAMEMASK];
-  lump = sprframe->lump[0];
-  flip = (boolean)sprframe->flip[0];
+  sprframenum = caststate->frame & FF_FRAMEMASK;
+  if (sprframenum < sprdef->numframes)
+  {
+    sprframe = &sprdef->spriteframes[ caststate->frame & FF_FRAMEMASK];
+    lump = sprframe->lump[0];
+    flip = (boolean)sprframe->flip[0];
 
-  // CPhipps - patch drawing updated
-  V_DrawNumPatch(160, 170, 0, lump+firstspritelump, CR_DEFAULT,
-     VPT_STRETCH | (flip ? VPT_FLIP : 0));
+    // CPhipps - patch drawing updated
+    V_DrawNumPatch(160, 170, 0, lump+firstspritelump, CR_DEFAULT,
+       VPT_STRETCH | (flip ? VPT_FLIP : 0));
+  }
 }
 
 //

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -724,6 +724,8 @@ void F_Drawer (void)
   else if (gamemapinfo) {
     if (!gamemapinfo->endpic[0])
       F_TextWrite();
+    else if (!stricmp(gamemapinfo->endpic, "$BUNNY"))
+       F_BunnyScroll ();
     else
     {
       V_DrawNamePatch(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -699,26 +699,22 @@ static void F_BunnyScroll (void)
 */
 void F_Drawer (void)
 {
-  if (gamemapinfo) {
-    if (!FinaleStage || !gamemapinfo->endpic[0])
-    {
-      F_TextWrite();
-    }
-    else
-    {
-      V_DrawNamePatch(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);
-      // e6y: wide-res
-      //V_FillBorder(-1, 0);
-    }
-    return;
-  }
-
   if (!FinaleStage)
     F_TextWrite ();
   else if (FinaleStage == 2)
   {
     F_CastDrawer ();
     return;
+  }
+  else if (gamemapinfo) {
+    if (!gamemapinfo->endpic[0])
+      F_TextWrite();
+    else
+    {
+      V_DrawNamePatch(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);
+      // e6y: wide-res
+      //V_FillBorder(-1, 0);
+    }
   }
   else
   {

--- a/src/f_finale.c
+++ b/src/f_finale.c
@@ -432,6 +432,10 @@ void F_StartCast (void)
   castonmelee = 0;
   castattacking = FALSE;
   S_ChangeMusic(mus_evil, TRUE);
+
+  // Fallback to CREDIT if Cast background is missing (eg. Doom1)
+  if (W_CheckNumForName(bgcastcall) == -1)
+     bgcastcall = "CREDIT";
 }
 
 

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2583,6 +2583,17 @@ static const uint8_t* G_ReadDemoHeader(const uint8_t *demo_p, size_t size, boole
    demover = *demo_p++;
    longtics = 0;
 
+   if (demover == 255) // UMAPINFO flag set
+   {
+     // Uses UMAPINFO. The real version will be in the second byte.
+     // This prepended 255 is here to prevent non-UMAPINFO ports from recognizing the demo.
+     demover = *demo_p++;
+     if (!U_mapinfo.mapcount)
+       I_Error("UMAPINFO not loaded but trying to play a demo recorded with it");
+   }
+   else if (U_mapinfo.mapcount)
+     I_Error("UMAPINFO loaded but trying to play a demo recorded without it");
+
    // e6y
    // Handling of unrecognized demo formats
    // Versions up to 1.2 use a 7-byte header - first byte is a skill level.

--- a/src/p_switch.c
+++ b/src/p_switch.c
@@ -148,11 +148,11 @@ void P_InitSwitchList(void)
       // Warn if either one is missing, but only add if both are valid.
       texture1 = R_CheckTextureNumForName(alphSwitchList[i].name1);
       if (texture1 == -1)
-        lprintf(LO_WARN, "P_InitSwitchList: unknown texture %s\n",
+        lprintf(LO_WARN, "P_InitSwitchList: unknown texture %.8s\n",
           alphSwitchList[i].name1);
       texture2 = R_CheckTextureNumForName(alphSwitchList[i].name2);
       if (texture2 == -1)
-        lprintf(LO_WARN, "P_InitSwitchList: unknown texture %s\n",
+        lprintf(LO_WARN, "P_InitSwitchList: unknown texture %.8s\n",
           alphSwitchList[i].name2);
       if (texture1 != -1 && texture2 != -1) {
         switchlist[index++] = texture1;

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -462,7 +462,10 @@ void S_ChangeMusic(int musicnum, int looping)
     return;
 
   if (musicnum <= mus_None || musicnum >= NUMMUSIC)
+  {
     I_Error("S_ChangeMusic: Bad music number %d", musicnum);
+    return;
+  }
 
   music = &S_music[musicnum];
 
@@ -478,6 +481,10 @@ void S_ChangeMusic(int musicnum, int looping)
     char namebuf[9];
     sprintf(namebuf, "d_%s", music->name);
     music->lumpnum = W_GetNumForName(namebuf);
+  }
+  if (music->lumpnum < 0) {
+    I_Error("S_ChangeMusic: No valid music lump");
+    return;
   }
   music_file_failed = 1;
 

--- a/src/u_mapinfo.c
+++ b/src/u_mapinfo.c
@@ -88,7 +88,7 @@ static char *ParseMultiString(u_scanner_t* s, int error)
       build = (char*)realloc(build, newlen);
       build[oldlen] = '\n';
       strcpy(build + oldlen + 1, s->string);
-      build[newlen] = 0;
+      build[newlen-1] = 0;
     }
   } while (U_CheckToken(s, ','));
   return build;
@@ -97,14 +97,20 @@ static char *ParseMultiString(u_scanner_t* s, int error)
 
 // -----------------------------------------------
 // Parses a lump name. The buffer must be at least 9 characters.
+// If parsed name is longer than 8 chars, sets NULL pointer.
+//
+// returns 1 on successfully parsing an element
+//         0 on parse error in last read token
 // -----------------------------------------------
 static int ParseLumpName(u_scanner_t* s, char *buffer)
 {
-  U_MustGetToken(s, TK_StringConst);
+  if (!U_MustGetToken(s, TK_StringConst))
+    return 0;
+
   if (strlen(s->string) > 8)
   {
     U_Error(s, "String too long. Maximum size is 8 characters.");
-    return 0;
+    return 1; // not a parse error
   }
   strncpy(buffer, s->string, 8);
   buffer[8] = 0;
@@ -117,58 +123,64 @@ static int ParseLumpName(u_scanner_t* s, char *buffer)
 // Parses a standard property that is already known
 // These do not get stored in the property list
 // but in dedicated struct member variables.
+//
+// returns 1 on successfully parsing an element
+//         0 on parse error in last read token
 // -----------------------------------------------
 static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
 {
   char *pname;
-  U_MustGetToken(s, TK_Identifier);
+  int status = 1; // 1 for success, 0 for parse error
+  if (!U_MustGetToken(s, TK_Identifier))
+    return 0;
+
   pname = strdup(s->string);
   U_MustGetToken(s, '=');
 
   if (!strcasecmp(pname, "levelname"))
   {
-    U_MustGetToken(s, TK_StringConst);
-    ReplaceString(&mape->levelname, s->string);
+    if (U_MustGetToken(s, TK_StringConst))
+      ReplaceString(&mape->levelname, s->string);
   }
   else if (!strcasecmp(pname, "episode"))
   {
     char *lname = ParseMultiString(s, 1);
-    if (!lname) return 0;
-    M_AddEpisode(mape->mapname, lname);
+    if (lname)
+      M_AddEpisode(mape->mapname, lname);
   }
   else if (!strcasecmp(pname, "next"))
   {
-    ParseLumpName(s, mape->nextmap);
+    status = ParseLumpName(s, mape->nextmap);
     if (!G_ValidateMapName(mape->nextmap, NULL, NULL))
     {
       U_Error(s, "Invalid map name %s.", mape->nextmap);
-      return 0;
+      status = 0;
     }
   }
   else if (!strcasecmp(pname, "nextsecret"))
   {
-    ParseLumpName(s, mape->nextsecret);
+    status = ParseLumpName(s, mape->nextsecret);
     if (!G_ValidateMapName(mape->nextsecret, NULL, NULL))
     {
       U_Error(s, "Invalid map name %s", mape->nextmap);
-      return 0;
+      status = 0;
     }
   }
   else if (!strcasecmp(pname, "levelpic"))
   {
-    ParseLumpName(s, mape->levelpic);
+    status = ParseLumpName(s, mape->levelpic);
   }
   else if (!strcasecmp(pname, "skytexture"))
   {
-    ParseLumpName(s, mape->skytexture);
+    status = ParseLumpName(s, mape->skytexture);
   }
   else if (!strcasecmp(pname, "music"))
   {
-    ParseLumpName(s, mape->music);
+    status = ParseLumpName(s, mape->music);
   }
   else if (!strcasecmp(pname, "endpic"))
   {
-    ParseLumpName(s, mape->endpic);
+    status = ParseLumpName(s, mape->endpic);
   }
   else if (!strcasecmp(pname, "endcast"))
   {
@@ -190,21 +202,21 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   }
   else if (!strcasecmp(pname, "exitpic"))
   {
-    ParseLumpName(s, mape->exitpic);
+    status = ParseLumpName(s, mape->exitpic);
   }
   else if (!strcasecmp(pname, "enterpic"))
   {
-    ParseLumpName(s, mape->enterpic);
+    status = ParseLumpName(s, mape->enterpic);
   }
   else if (!strcasecmp(pname, "nointermission"))
   {
-    U_MustGetToken(s, TK_BoolConst);
-    mape->nointermission = s->boolean;
+    if (U_MustGetToken(s, TK_BoolConst))
+      mape->nointermission = s->boolean;
   }
   else if (!strcasecmp(pname, "partime"))
   {
-    U_MustGetInteger(s);
-    mape->partime = TICRATE * s->number;
+    if (U_MustGetInteger(s))
+      mape->partime = TICRATE * s->number;
   }
   else if (!strcasecmp(pname, "intertext"))
   {
@@ -222,53 +234,53 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   }
   else if (!strcasecmp(pname, "interbackdrop"))
   {
-    ParseLumpName(s, mape->interbackdrop);
+    status = ParseLumpName(s, mape->interbackdrop);
   }
   else if (!strcasecmp(pname, "intermusic"))
   {
-    ParseLumpName(s, mape->intermusic);
+    status = ParseLumpName(s, mape->intermusic);
   }
   else if (!strcasecmp(pname, "bossaction"))
   {
-    int special, tag;
-    U_MustGetToken(s, TK_Identifier);
-    if (!strcasecmp(s->string, "clear"))
+    if (U_MustGetToken(s, TK_Identifier))
     {
-      // mark level free of boss actions
-      special = tag = -1;
-      if (mape->bossactions) free(mape->bossactions);
-      mape->bossactions = NULL;
-      mape->numbossactions = -1;
-    }
-    else
-    {
-      int i;
-      for (i = 0; i < NUMMOBJTYPES; i++)
+      if (!strcasecmp(s->string, "clear"))
       {
-        if (mobjinfo[i].actorname != NULL && !strcasecmp(s->string, mobjinfo[i].actorname))
-        {
-          U_MustGetToken(s, ',');
-          U_MustGetInteger(s);
-          special = s->number;
-          U_MustGetToken(s, ',');
-          U_MustGetInteger(s);
-          tag = s->number;
-          // allow no 0-tag specials here, unless a level exit.
-          if (tag != 0 || special == 11 || special == 51 || special == 52 || special == 124)
-          {
-            if (mape->numbossactions == -1) mape->numbossactions = 1;
-            else mape->numbossactions++;
-            mape->bossactions = (bossaction_t *)realloc(mape->bossactions,
-                                                        sizeof(bossaction_t)*mape->numbossactions);
-            mape->bossactions[mape->numbossactions - 1].type = i;
-            mape->bossactions[mape->numbossactions - 1].special = special;
-            mape->bossactions[mape->numbossactions - 1].tag = tag;
-          }
-          break;
-        }
+        // mark level free of boss actions
+        if (mape->bossactions) free(mape->bossactions);
+        mape->bossactions = NULL;
+        mape->numbossactions = -1;
       }
-      U_Error(s, "bossaction: unknown thing type '%s'", s->string);
-      return 0;
+      else
+      {
+        int i, special, tag;
+        for (i = 0; i < NUMMOBJTYPES; i++)
+        {
+          if (mobjinfo[i].actorname != NULL && !strcasecmp(s->string, mobjinfo[i].actorname))
+          {
+            U_MustGetToken(s, ',');
+            U_MustGetInteger(s);
+            special = s->number;
+            U_MustGetToken(s, ',');
+            U_MustGetInteger(s);
+            tag = s->number;
+            // allow no 0-tag specials here, unless a level exit.
+            if (tag != 0 || special == 11 || special == 51 || special == 52 || special == 124)
+            {
+              if (mape->numbossactions == -1) mape->numbossactions = 1;
+              else mape->numbossactions++;
+              mape->bossactions = (bossaction_t *)realloc(mape->bossactions,
+                                                        sizeof(bossaction_t)*mape->numbossactions);
+              mape->bossactions[mape->numbossactions - 1].type = i;
+              mape->bossactions[mape->numbossactions - 1].special = special;
+              mape->bossactions[mape->numbossactions - 1].tag = tag;
+            }
+            break;
+          }
+        }
+        if (i == NUMMOBJTYPES)
+          U_Error(s, "bossaction: unknown thing type '%s'", s->string);
+      }
     }
   }
   // If no known property name was given, skip all comma-separated values after the = sign
@@ -278,7 +290,7 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   } while (U_CheckToken(s, ','));
 
   free(pname);
-  return 1;
+  return status;
 }
 
 // -----------------------------------------------
@@ -304,7 +316,8 @@ static int ParseMapEntry(u_scanner_t *s, mapentry_t *val)
   U_MustGetToken(s, '{');
   while(!U_CheckToken(s, '}'))
   {
-    ParseStandardProperty(s, val);
+    if(!ParseStandardProperty(s, val))
+      U_GetNextToken(s, TRUE); // If there was an error parsing, skip to next token
   }
   return 1;
 }

--- a/src/u_mapinfo.c
+++ b/src/u_mapinfo.c
@@ -120,8 +120,9 @@ static int ParseLumpName(u_scanner_t* s, char *buffer)
 // -----------------------------------------------
 static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
 {
+  char *pname;
   U_MustGetToken(s, TK_Identifier);
-  char *pname = strdup(s->string);
+  pname = strdup(s->string);
   U_MustGetToken(s, '=');
 
   if (!strcasecmp(pname, "levelname"))
@@ -229,8 +230,8 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
   }
   else if (!strcasecmp(pname, "bossaction"))
   {
-    U_MustGetToken(s, TK_Identifier);
     int special, tag;
+    U_MustGetToken(s, TK_Identifier);
     if (!strcasecmp(s->string, "clear"))
     {
       // mark level free of boss actions
@@ -266,17 +267,14 @@ static int ParseStandardProperty(u_scanner_t* s, mapentry_t *mape)
           break;
         }
       }
-      U_Error(s, "Unknown thing type %s", s->string);
+      U_Error(s, "bossaction: unknown thing type '%s'", s->string);
       return 0;
     }
   }
-  else do
+  // If no known property name was given, skip all comma-separated values after the = sign
+  else if (s->token == '=') do
   {
-    if (!U_CheckFloat(s)) U_GetNextToken(s, TRUE);
-    if (s->token > TK_BoolConst)
-    {
-      U_ErrorToken(s, TK_Identifier);
-    }
+    U_GetNextToken(s, TRUE);
   } while (U_CheckToken(s, ','));
 
   free(pname);


### PR DESCRIPTION
This will make ending sequences for doom2 and doom1 supported on UMAPINFO maps.
You can use Doom2 finale animation in a Doom1 wad (the cast will only show monsters that are available for each game) and viceversa.

Also, the parser was made a bit more stable, preventing crashes that I found when trying some cases with bad UMAPINFO syntax or unknown properties.