### PR TITLE
Support RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -244,54 +244,60 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 {
   switch(movement_smooth)
   {
-    case 0:
+    case 1:
       info->timing.fps = 35.0;
       break;
-    case 1:
+    case 2:
       info->timing.fps = 40.0;
       break;
-    case 2:
+    case 3:
       info->timing.fps = 50.0;
       break;
-    case 3:
+    case 4:
       info->timing.fps = 60.0;
       break;
-    case 4:
+    case 5:
       info->timing.fps = 70.0;
       break;
-    case 5:
+    case 6:
       info->timing.fps = 72.0;
       break;
-    case 6:
+    case 7:
       info->timing.fps = 75.0;
       break;
-    case 7:
+    case 8:
       info->timing.fps = 90.0;
       break;
-    case 8:
+    case 9:
       info->timing.fps = 100.0;
       break;
-    case 9:
+    case 10:
       info->timing.fps = 119.0;
       break;
-    case 10:
+    case 11:
       info->timing.fps = 120.0;
       break;
-    case 11:
+    case 12:
       info->timing.fps = 140.0;
       break;
-    case 12:
+    case 13:
       info->timing.fps = 144.0;
       break;
-    case 13:
+    case 14:
       info->timing.fps = 240.0;
       break;
-    case 14:
+    case 15:
       info->timing.fps = 244.0;
       break;
+    case 0: // Auto
     default:
-      info->timing.fps = TICRATE;
+    {
+      float target_framerate = 0.0f;
+      if (!environ_cb(RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE, &target_framerate))
+        target_framerate = 60.0f;
+      info->timing.fps = target_framerate;
       break;
+    }
   }
   info->timing.sample_rate = 44100.0;
   info->geometry.base_width = SCREENWIDTH;
@@ -1413,6 +1419,9 @@ void R_InitInterpolation(void)
     tic_vars.fps = info.timing.fps;
     tic_vars.frac_step = FRACUNIT * TICRATE / tic_vars.fps;
     tic_vars.sample_step = info.timing.sample_rate / tic_vars.fps;
+
+    if (log_cb)
+      log_cb(RETRO_LOG_INFO, "[libretro]: Framerate set to %.2f FPS\n", info.timing.fps);
   }
   tic_vars.frac = FRACUNIT;
 }

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -2837,7 +2837,7 @@ enum {
 #define G_YA3 (G_YA2 + 16)
 #define GF_X 76
 
-static const char *framerates[] = {"35fps", "40fps", "50fps", "60fps", "70fps", "72fps", "75fps", "90fps", "100fps", "119fps", "120fps", "140fps", "144fps", "240fps", "244fps", NULL};
+static const char *framerates[] = {"Auto", "35fps", "40fps", "50fps", "60fps", "70fps", "72fps", "75fps", "90fps", "100fps", "119fps", "120fps", "140fps", "144fps", "240fps", "244fps", NULL};
 static const char *gamma_lvls[] = {"OFF", "Lv. 1", "Lv. 2", "Lv. 3", "Lv. 4", NULL};
 static const char *mus_external_opts[] = {"Never", "Always", "Only IWAD", NULL};
 

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -295,7 +295,7 @@ default_t defaults[] =
    def_int,ss_none, NULL, NULL},
   {"usegamma",{&usegamma, NULL},{0, NULL},0,4, //jff 3/6/98 fix erroneous upper limit in range
    def_int,ss_gen, NULL, NULL}, // gamma correction level // killough 1/18/98
-  {"uncapped_framerate", {&movement_smooth, NULL},  {3, NULL},0,14,
+  {"uncapped_framerate", {&movement_smooth, NULL},  {0, NULL},0,15,
    def_int,ss_gen, NULL, NULL},
   {"filter_wall",{(int*)&drawvars.filterwall, NULL},{RDRAW_FILTER_POINT, NULL},
    RDRAW_FILTER_POINT, RDRAW_FILTER_ROUNDED, def_int,ss_gen, NULL, NULL},


### PR DESCRIPTION
I've just read the exciting blog post on https://www.libretro.com/index.php/upcoming-retroarch-1-7-4-sync-to-exact-content-frame-rate-ideal-for-g-syncfreesync-users/

I went ahead and added the "auto" Framerate option to use the reported framerate from the frontend targeted refresh rate.
It'll also be set as the new default for the Framerate option. It'll fallback to 60 FPS if not obtained.