### PR TITLE
Fixes for eternall.wad and musinfo

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -352,7 +352,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 			break;
 		default:
 			if (log_cb)
-				log_cb(RETRO_LOG_ERROR, "[libretro]: Invalid device, setting type to RETROPAD_CLASSIC ...\n");
+				log_cb(RETRO_LOG_ERROR, "Invalid libretro controller device, using default: RETROPAD_CLASSIC\n");
 			doom_devices[port] = RETROPAD_CLASSIC;
 			environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, gp_classic.desc);
 	}
@@ -1427,7 +1427,7 @@ void R_InitInterpolation(void)
     tic_vars.sample_step = info.timing.sample_rate / tic_vars.fps;
 
     if (log_cb)
-      log_cb(RETRO_LOG_INFO, "[libretro]: Framerate set to %.2f FPS\n", info.timing.fps);
+      log_cb(RETRO_LOG_INFO, "R_InitInterpolation: Framerate set to %.2f FPS\n", info.timing.fps);
   }
   tic_vars.frac = FRACUNIT;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -1,6 +1,9 @@
 /* config.h.  Generated from config.h.in by configure.  */
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
 /* Define to be the path where Doom WADs are stored */
 #define DOOMWADDIR "/usr/local/share/games/doom"
 
@@ -77,3 +80,5 @@ extern int SCREENHEIGHT;
 
 /* Define to strncasecmp, if we have it */
 #define strnicmp strncasecmp
+
+#endif

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1791,9 +1791,7 @@ static void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
   }
 
   if (fpout) fprintf(fpout,"Thing %d (%s) -> line: '%s'\n", indexnum+1,
-                     ((indexnum >= 0 && indexnum < NUMMOBJTYPES)?
-                      mobjinfo[indexnum].actorname : "undefined"),
-                     inbuffer);
+                      mobjinfo[indexnum].actorname, inbuffer);
 
   // now process the stuff
   // Note that for Things we can look up the key and use its offset

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -688,10 +688,10 @@ static char *FindIWADFile(void)
   char  * iwad  = NULL;
 
   i = M_CheckParm("-iwad");
-  lprintf(LO_ALWAYS, "i: %d\n", i);
+  lprintf(LO_DEBUG, "i: %d\n", i);
 
   for(x = 0; x < 32; x++)
-     lprintf(LO_ALWAYS, "myargv[%d]: %s\n", x, myargv[x]);
+     lprintf(LO_DEBUG, "myargv[%d]: %s\n", x, myargv[x]);
 
   if (i && (++i < myargc)) {
     iwad = I_FindFile(myargv[i], NULL);
@@ -732,7 +732,7 @@ static bool IdentifyVersion (void)
   // set save path to -save parm or current dir
 
   strcpy(basesavegame,I_DoomExeDir());
-  lprintf(LO_ALWAYS, "IdentifyVersion: basesavegame: %s\n", basesavegame);
+  lprintf(LO_INFO, "IdentifyVersion: basesavegame: %s\n", basesavegame);
 #ifndef __CELLOS_LV2__
   if ((i=M_CheckParm("-save")) && i<myargc-1) //jff 3/24/98 if -save present
   {
@@ -749,7 +749,7 @@ static bool IdentifyVersion (void)
   // locate the IWAD and determine game mode from it
 
   iwad = FindIWADFile();
-  lprintf(LO_ALWAYS, "iwad: %s\n", iwad);
+  lprintf(LO_INFO, "iwad: %s\n", iwad);
 
   if (iwad && *iwad)
   {
@@ -1157,7 +1157,7 @@ bool D_DoomMainSetup(void)
     }
 
     /* cphipps - the main display. This shows the build date, copyright, and game type */
-    lprintf(LO_ALWAYS,"PrBoom, playing: %s\n"
+    lprintf(LO_INFO,"PrBoom, playing: %s\n"
       "PrBoom is released under the GNU General Public license v2.0.\n"
       "You are welcome to redistribute it under certain conditions.\n"
       "It comes with ABSOLUTELY NO WARRANTY. See the file COPYING for details.\n",

--- a/src/dbopl.h
+++ b/src/dbopl.h
@@ -16,6 +16,9 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
+#ifndef __DBOPL_H__
+#define __DBOPL_H__
+
 #include <stdint.h>
 
 #ifdef _MSC_VER
@@ -212,5 +215,6 @@ void DBOPL_InitTables( void );
 void Chip__Chip(Chip *self);
 void Chip__WriteReg(Chip *self, Bit32u reg, Bit8u val );
 void Chip__GenerateBlock2(Chip *self, Bitu total, Bit32s* output );
+#endif
 
 #endif

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -544,10 +544,8 @@ static void G_DoLoadLevel (void)
 {
   int i;
 
-  lprintf(LO_ALWAYS,
-          "---------------------------------\n"
-          "G_DoLoadLevel: Episode %d - Map %.2d\n"
-          "---------------------------------\n",
+  lprintf(LO_INFO, "------------------------------\n"
+          "G_DoLoadLevel:  ===== Episode %d - Map %.2d =====\n",
           gameepisode, gamemap);
 
   /* Set the sky map for the episode.

--- a/src/lprintf.c
+++ b/src/lprintf.c
@@ -47,12 +47,12 @@
 /* cphipps - enlarged message buffer and made non-static
  * We still have to be careful here, this function can be called after exit
  */
-#define MAX_MESSAGE_SIZE 2048
 
+#ifndef __LIBRETRO__
 int lprintf(OutputLevels pri, const char *s, ...)
 {
   int r=0;
-  char msg[MAX_MESSAGE_SIZE];
+  char msg[MAX_LOG_MESSAGE_SIZE];
 
   va_list v;
   va_start(v,s);
@@ -67,6 +67,7 @@ int lprintf(OutputLevels pri, const char *s, ...)
 
   return r;
 }
+#endif
 
 /*
  * I_Error
@@ -79,7 +80,7 @@ int lprintf(OutputLevels pri, const char *s, ...)
 
 bool I_Error(const char *error, ...)
 {
-  char errmsg[MAX_MESSAGE_SIZE];
+  char errmsg[MAX_LOG_MESSAGE_SIZE];
   va_list argptr;
   va_start(argptr,error);
 #ifdef HAVE_VSNPRINTF

--- a/src/lprintf.h
+++ b/src/lprintf.h
@@ -36,6 +36,11 @@
 
 #include <boolean.h>
 
+/* cphipps - enlarged message buffer and made non-static
+ * We still have to be careful here, this function can be called after exit
+ */
+#define MAX_LOG_MESSAGE_SIZE 2048
+
 typedef enum                /* Logical output levels */
 {
   LO_INFO=1,                /* One of these is used in each physical output    */

--- a/src/m_argv.c
+++ b/src/m_argv.c
@@ -52,8 +52,8 @@ const char * const * myargv; // CPhipps - not sure if ANSI C allows you to
 int M_CheckParm(const char *check)
 {
 #if 0
-  lprintf(LO_ALWAYS, "M_CheckParm: Checking %s...\n", check);
-  lprintf(LO_ALWAYS, "M_CheckParm: myargc: %d, myargc - 1: %d\n", myargc, myargc-1);
+  lprintf(LO_DEBUG, "M_CheckParm: Checking %s...\n", check);
+  lprintf(LO_DEBUG, "M_CheckParm: myargc: %d, myargc - 1: %d\n", myargc, myargc-1);
 #endif
   signed int i = myargc;
   while (--i>0)

--- a/src/p_checksum.h
+++ b/src/p_checksum.h
@@ -1,4 +1,9 @@
+#ifndef __PCHECKSUM_H__
+#define __PCHECKSUM_H__
+
 extern void (*P_Checksum)(int);
 extern void P_ChecksumFinal(void);
 void P_RecordChecksum(const char *file);
 //void P_VerifyChecksum(const char *file);
+
+#endif

--- a/src/p_pspr.c
+++ b/src/p_pspr.c
@@ -801,7 +801,7 @@ void A_FireOldBFG(player_t *player, pspdef_t *psp)
     th->momz = finetangent[an2>>ANGLETOFINESHIFT] * 25;
     P_CheckMissileSpawn(th);
   }
-  while ((type != MT_PLASMA2) && (type = MT_PLASMA2)); //killough: obfuscated!
+  while ((type != MT_PLASMA2) && (type = MT_PLASMA2)); //killough: obfuscated! // lgtm[cpp/assign-where-compare-meant]
 }
 
 //

--- a/src/r_demo.h
+++ b/src/r_demo.h
@@ -32,6 +32,9 @@
  *---------------------------------------------------------------------
  */
 
+#ifndef __RDEMO_H__
+#define __RDEMO_H__
+
 #include "doomstat.h"
 
 #define SMOOTH_PLAYING_MAXFACTOR 16 
@@ -43,3 +46,5 @@ void R_SmoothPlaying_Reset(player_t *player);
 void R_SmoothPlaying_Add(int delta);
 angle_t R_SmoothPlaying_Get(angle_t defangle);
 void R_ResetAfterTeleport(player_t *player);
+
+#endif

--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -659,7 +659,10 @@ void R_StoreWallRange(const int start, const int stop)
       ds_p->scalestep = rw_scalestep = (ds_p->scale2-rw_scale) / (stop-start);
    }
    else
+   {
       ds_p->scale2 = ds_p->scale1;
+      ds_p->scalestep = 0;
+   }
 
    // calculate texture boundaries
    //  and decide if floor / ceiling marks are needed

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -543,7 +543,12 @@ void S_ChangeMusicByName(char* lumpname, int looping)
     musicinfo_t *music = &S_music[NUMMUSIC];
     int lumpnum = W_CheckNumForName(lumpname);
 
-    if ((lumpnum < -1) || (mus_playing && mus_playing->lumpnum == lumpnum))
+    if (lumpnum <= -1)
+    {
+       I_Error("S_ChangeMusicByName: invalid lump name '%s'", lumpname);
+       return;
+    }
+    if(mus_playing && mus_playing->lumpnum == lumpnum)
       return;
 
     // shutdown old music

--- a/src/u_scanner.c
+++ b/src/u_scanner.c
@@ -443,6 +443,21 @@ boolean U_GetNextToken(u_scanner_t* scanner, boolean expandState)
   return FALSE;
 }
 
+/**
+ * Skips all Tokens in current line and parses the first token on
+ * the next line.
+ */
+boolean U_GetNextLineToken(u_scanner_t* scanner)
+{
+  unsigned int line = scanner->line;
+  boolean retval = FALSE;
+
+  do retval = U_GetNextToken(scanner, TRUE);
+  while (retval && scanner->line == line);
+
+  return retval;
+}
+
 
 void U_ErrorToken(u_scanner_t* s, int token)
 {

--- a/src/u_scanner.c
+++ b/src/u_scanner.c
@@ -391,6 +391,9 @@ boolean U_GetNextToken(u_scanner_t* scanner, boolean expandState)
       else
         break;
     }
+    // If we reached end of input while reading, set it as the end of token
+    if(scanner->scanPos == scanner->length && start == end)
+      end = scanner->length;
   }
 
   if(end-start > 0 || stringFinished)

--- a/src/u_scanner.h
+++ b/src/u_scanner.h
@@ -91,6 +91,7 @@ typedef struct
 u_scanner_t  U_ScanOpen(const char* data, int length, const char *name);
 void         U_ScanClose(u_scanner_t* scanner);
 boolean      U_GetNextToken(u_scanner_t* scanner, boolean expandState);
+boolean      U_GetNextLineToken(u_scanner_t* scanner);
 boolean      U_HasTokensLeft(u_scanner_t* scanner);
 boolean      U_MustGetToken(u_scanner_t* scanner, char token);
 boolean      U_MustGetIdentifier(u_scanner_t* scanner, const char *ident);

--- a/src/z_bmalloc.h
+++ b/src/z_bmalloc.h
@@ -31,6 +31,9 @@
  *  This is designed to be a fast allocator for small, regularly used block sizes
  *-----------------------------------------------------------------------------*/
 
+#ifndef __ZBMALLOC_H__
+#define __ZBMALLOC_H__
+
 struct block_memory_alloc_s {
   void  *firstpool;
   size_t size;
@@ -50,3 +53,5 @@ static INLINE void* Z_BCalloc(struct block_memory_alloc_s *pzone)
 { void *p = Z_BMalloc(pzone); memset(p,0,pzone->size); return p; }
 
 void Z_BFree(struct block_memory_alloc_s *pzone, void* p);
+
+#endif


### PR DESCRIPTION
This adds a couple of fixes.

One is the scalestep for drawsegs being uninitialized in some wads like `eternall.wad` (from [Eternal Doom](https://www.doomworld.com/idgames/themes/TeamTNT/eternal/eternal) PWAD, not to be confused with Doom Eternal :P), which I noticed when checkin it through valgrind (related to #118, and maybe it can fix it).

I also fixed some oversights on my part when I made the MUSINFO parsing reuse the same scanner as UMAPINFO, and some warnings found by LGTM.