### PR TITLE
Interpolation on state serialization

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -457,8 +457,6 @@ static void update_variables(bool startup)
 
 void I_SafeExit(int rc);
 
-static fixed_t unserial_time = 0;
-
 void retro_run(void)
 {
    bool updated = false;
@@ -469,10 +467,6 @@ void retro_run(void)
       environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, NULL);
       I_SafeExit(1);
    }
-
-   if (pause_interpolations && tic_vars.frac / FRACUNIT > unserial_time / FRACUNIT)
-     pause_interpolations = false;
-
    D_DoomLoop();
    I_UpdateSound();
 }
@@ -764,8 +758,9 @@ extern boolean gamekeydown[NUMKEYS];
 static bool old_input[MAX_BUTTON_BINDS];
 
 struct extra_serialize {
-  uint32_t gametic;
   uint32_t extra_size;
+  uint32_t gametic;
+  fixed_t  gameticfrac;
   uint32_t gameaction;
   uint32_t turnheld;
   uint32_t gamestate;
@@ -779,6 +774,11 @@ struct extra_serialize {
   uint8_t  autorun;
   uint8_t  gameless;
   uint8_t  menuactive;
+  fixed_t  prevx;
+  fixed_t  prevy;
+  fixed_t  prevz;
+  angle_t  prevangle;
+  angle_t  prevpitch;
   uint8_t  old_input[MAX_BUTTON_BINDS];
   uint8_t  gamekeydown[NUMKEYS];
 };
@@ -800,8 +800,14 @@ bool retro_serialize(void *data_, size_t size)
     if (!ret) {
       return false;
     }
+    extra->prevx = viewplayer->mo->PrevX;
+    extra->prevy = viewplayer->mo->PrevY;
+    extra->prevz = viewplayer->prev_viewz;
+    extra->prevangle = viewplayer->prev_viewangle;
+    extra->prevpitch = viewplayer->prev_viewpitch;
   }
   extra->gametic = gametic;
+  extra->gameticfrac = tic_vars.frac;
   extra->gameaction = gameaction;
   extra->turnheld = turnheld;
   extra->extra_size = sizeof(*extra);
@@ -841,7 +847,7 @@ bool retro_unserialize(const void *data_, size_t size)
   if (extra->extra_size == sizeof(*extra))
     {
       unsigned i;
-      gametic = extra->gametic;
+      gametic = maketic = extra->gametic;
       gameaction = extra->gameaction;
       turnheld = extra->turnheld;
       autorun = extra->autorun;
@@ -858,11 +864,15 @@ bool retro_unserialize(const void *data_, size_t size)
       for (i = 0; i < MAX_BUTTON_BINDS; i++)
 	old_input[i] = extra->old_input[i];
       menuactive = extra->menuactive;
+      tic_vars.frac = extra->gameticfrac;
+      if (viewplayer && viewplayer->mo) {
+        viewplayer->mo->PrevX = extra->prevx;
+        viewplayer->mo->PrevY = extra->prevy;
+        viewplayer->prev_viewz = extra->prevz;
+        viewplayer->prev_viewangle = extra->prevangle;
+        viewplayer->prev_viewpitch = extra->prevpitch;
+      }
     }
-  R_StopAllInterpolations();
-  R_ResetViewInterpolation ();
-  pause_interpolations = true;
-  unserial_time = tic_vars.frac;
   return true;
 }
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -785,7 +785,7 @@ struct extra_serialize {
 
 size_t retro_serialize_size(void)
 {
-  return 0x20000 + sizeof(struct extra_serialize);
+  return sizeof(struct extra_serialize) + 0x30000;
 }
 
 bool retro_serialize(void *data_, size_t size)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -764,6 +764,7 @@ extern boolean gamekeydown[NUMKEYS];
 static bool old_input[MAX_BUTTON_BINDS];
 
 struct extra_serialize {
+  uint32_t gametic;
   uint32_t extra_size;
   uint32_t gameaction;
   uint32_t turnheld;
@@ -773,7 +774,6 @@ struct extra_serialize {
   uint32_t set_menu_itemon;
   struct wi_state wi_state;
   short itemOn;
-  short skullAnimCounter;
   short whichSkull;
   short currentMenu;
   uint8_t  autorun;
@@ -801,6 +801,7 @@ bool retro_serialize(void *data_, size_t size)
       return false;
     }
   }
+  extra->gametic = gametic;
   extra->gameaction = gameaction;
   extra->turnheld = turnheld;
   extra->extra_size = sizeof(*extra);
@@ -810,7 +811,6 @@ bool retro_serialize(void *data_, size_t size)
   extra->FinaleCount = FinaleCount;
   extra->gameless = gameless;
   extra->itemOn = itemOn;
-  extra->skullAnimCounter = skullAnimCounter;
   extra->whichSkull = whichSkull;
   extra->currentMenu = 0;
   extra->set_menu_itemon = set_menu_itemon;
@@ -841,6 +841,7 @@ bool retro_unserialize(const void *data_, size_t size)
   if (extra->extra_size == sizeof(*extra))
     {
       unsigned i;
+      gametic = extra->gametic;
       gameaction = extra->gameaction;
       turnheld = extra->turnheld;
       autorun = extra->autorun;
@@ -849,7 +850,6 @@ bool retro_unserialize(const void *data_, size_t size)
       FinaleCount = extra->FinaleCount;
       WI_Load(&extra->wi_state);
       itemOn = extra->itemOn;
-      skullAnimCounter = extra->skullAnimCounter;
       whichSkull = extra->whichSkull;
       currentMenu = menus[extra->currentMenu];
       set_menu_itemon = extra->set_menu_itemon;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -799,11 +799,13 @@ bool retro_serialize(void *data_, size_t size)
     if (!ret) {
       return false;
     }
-    extra->prevx = viewplayer->mo->PrevX;
-    extra->prevy = viewplayer->mo->PrevY;
-    extra->prevz = viewplayer->prev_viewz;
-    extra->prevangle = viewplayer->prev_viewangle;
-    extra->prevpitch = viewplayer->prev_viewpitch;
+    if (viewplayer && viewplayer->mo) {
+      extra->prevx = viewplayer->mo->PrevX;
+      extra->prevy = viewplayer->mo->PrevY;
+      extra->prevz = viewplayer->prev_viewz;
+      extra->prevangle = viewplayer->prev_viewangle;
+      extra->prevpitch = viewplayer->prev_viewpitch;
+    }
   }
   extra->gametic = gametic;
   extra->gameticfrac = tic_vars.frac;

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -534,24 +534,24 @@ void D_BuildNewTiccmds(void)
 void TryRunTics(void)
 {
   fixed_t overflow = 0;
-  // Increment tic fraction if game is ongoing
-  if ((demoplayback || !menuactive) && !paused)
-  {
-     tic_vars.frac += tic_vars.frac_step;
-     if(tic_vars.frac > FRACUNIT) {
-        overflow = tic_vars.frac - FRACUNIT;
-        tic_vars.frac = FRACUNIT;
-     }
+
+  // Increment tic fraction
+  tic_vars.frac += tic_vars.frac_step;
+  if(tic_vars.frac > FRACUNIT) {
+    overflow = tic_vars.frac - FRACUNIT;
+    tic_vars.frac = FRACUNIT;
   }
 
   D_BuildNewTiccmds();
 
   if(tic_vars.frac == FRACUNIT) {
     tic_vars.frac = overflow;
-    if (advancedemo)
-      D_DoAdvanceDemo ();
+    if (!paused) {
+      if (advancedemo)
+        D_DoAdvanceDemo ();
+      G_Ticker ();
+    }
     M_Ticker ();
-    G_Ticker ();
     P_Checksum(gametic);
     gametic++;
   }

--- a/src/d_client.c
+++ b/src/d_client.c
@@ -551,7 +551,8 @@ void TryRunTics(void)
         D_DoAdvanceDemo ();
       G_Ticker ();
     }
-    M_Ticker ();
+    if (menuactive)
+      M_Ticker ();
     P_Checksum(gametic);
     gametic++;
   }

--- a/src/d_deh.c
+++ b/src/d_deh.c
@@ -1849,9 +1849,9 @@ static void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
               if (strcasecmp(strval,deh_mobjflags[iy].name)) continue;
               if (fpout) {
                 fprintf(fpout,
-                  "ORed value 0x%08lX%08lX %s\n",
-                  (unsigned long)(deh_mobjflags[iy].value>>32) & 0xffffffff,
-                  (unsigned long)deh_mobjflags[iy].value & 0xffffffff, strval
+                  "ORed value 0x%08"PRIX64"%08"PRIX64" %s\n",
+                  (uint64_t)(deh_mobjflags[iy].value>>32) & 0xffffffff,
+                  (uint64_t)deh_mobjflags[iy].value & 0xffffffff, strval
                 );
               }
               value |= deh_mobjflags[iy].value;
@@ -1872,8 +1872,8 @@ static void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
 
           if (fpout)
             fprintf(fpout,
-                    "Result  =  0x%016lX\n"
-                    "Current    0x%016lX\n",
+                    "Result  =  0x%016"PRIX64"\n"
+                    "Current    0x%016"PRIX64"\n",
                     value, mobjinfo[indexnum].flags);
 
           // Each "Bits" field can use any mnemonic, but it won't overwrite the values
@@ -1889,9 +1889,9 @@ static void deh_procThing(DEHFILE *fpin, FILE* fpout, char *line)
       setMobjInfoValue(indexnum, ix, value);
       if (fpout) {
         fprintf(fpout,
-          "Assigned 0x%08lx%08lx to %s(%d) at index %d\n",
-          (unsigned long)(value>>32) & 0xffffffff,
-          (unsigned long)value & 0xffffffff, key, indexnum, ix
+          "Assigned 0x%08"PRIx64"%08"PRIx64" to %s(%d) at index %d\n",
+          (uint64_t)(value>>32) & 0xffffffff,
+          (uint64_t)value & 0xffffffff, key, indexnum, ix
         );
       }
     }

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1514,7 +1514,7 @@ void D_DoomLoop(void)
    if (players[displayplayer].mo) // cph 2002/08/10
       S_UpdateSounds(players[displayplayer].mo);// move positional sounds
 
-   if (!movement_smooth || pause_interpolations || !WasRenderedInTryRunTics || gamestate != wipegamestate)
+   if (!movement_smooth || !WasRenderedInTryRunTics || gamestate != wipegamestate)
    {
       // Update display, next frame, with current state.
       D_Display();

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -46,6 +46,8 @@
 
 #ifndef PRIu64
 #define PRIu64 "I64u"
+#define PRIX64 "I64X"
+#define PRIx64 "I64x"
 #endif
 
 //e6y

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2007,7 +2007,7 @@ bool G_DoSaveGameToBuffer(void *buf, size_t size) {
 
   int ok = ((size_t) length <= size);
 
-  if (ok && size != length) {
+  if (ok && size != (size_t)length) {
     // initialize the rest with zeroes
     memset(buf+length, 0, size - length);
   } else if (savebuffer != NULL) {

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -1994,14 +1994,10 @@ bool G_DoSaveGameToBuffer(void *buf, size_t size) {
   // If no game is loaded we can't save
   if (thinkercap.next == NULL)
     return false;
-  gameaction_t ga_saved = gameaction;
   char         description_saved[SAVEDESCLEN];
 
   memcpy(description_saved, savedescription, SAVEDESCLEN);
   strcpy(savedescription, "BUFFER");
-
-  gameaction = ga_nothing; // cph - cancel savegame at top of this function,
-    // in case later problems cause a premature exit
 
   // set savebuffer and its size to attempt to save directly into the destination buffer
   savebuffer = buf;
@@ -2022,7 +2018,6 @@ bool G_DoSaveGameToBuffer(void *buf, size_t size) {
 
   savebuffer = save_p = NULL;
   memcpy(savedescription, description_saved, SAVEDESCLEN);
-  gameaction = ga_saved;
 
   return ok;
 }

--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -187,7 +187,6 @@ typedef struct menu_s
 } menu_t;
 
 short itemOn;           // menu item skull is on (for Big Font menus)
-short skullAnimCounter; // skull animation counter
 short whichSkull;       // which skull to draw (he blinks)
 
 // graphic name of skulls
@@ -5167,10 +5166,9 @@ void M_SetupNextMenu(menu_t *menudef)
 //
 void M_Ticker (void)
 {
-  if (--skullAnimCounter <= 0)
+  if (gametic % 8 == 0)
     {
       whichSkull ^= 1;
-      skullAnimCounter = 8;
     }
 }
 
@@ -5394,7 +5392,6 @@ void M_Init(void)
   menuactive = mnact_inactive;
   itemOn = currentMenu->lastOn;
   whichSkull = 0;
-  skullAnimCounter = 10;
   messageToPrint = 0;
   messageString = NULL;
   messageLastMenuActive = menuactive;

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -503,12 +503,11 @@ void P_UnArchiveThinkers (void)
 
       if (mobj->player)
         (mobj->player = &players[(uintptr_t) mobj->player - 1]) -> mo = mobj;
-      else {
-        // avoid glitchy interpolation on non-player objects
-        mobj->PrevX = mobj->x;
-        mobj->PrevY = mobj->y;
-        mobj->PrevZ = mobj->z;
-      }
+
+      // avoid glitchy interpolation
+      mobj->PrevX = mobj->x;
+      mobj->PrevY = mobj->y;
+      mobj->PrevZ = mobj->z;
 
       P_SetThingPosition (mobj);
       mobj->info = &mobjinfo[mobj->type];

--- a/src/p_saveg.c
+++ b/src/p_saveg.c
@@ -503,6 +503,12 @@ void P_UnArchiveThinkers (void)
 
       if (mobj->player)
         (mobj->player = &players[(uintptr_t) mobj->player - 1]) -> mo = mobj;
+      else {
+        // avoid glitchy interpolation on non-player objects
+        mobj->PrevX = mobj->x;
+        mobj->PrevY = mobj->y;
+        mobj->PrevZ = mobj->z;
+      }
 
       P_SetThingPosition (mobj);
       mobj->info = &mobjinfo[mobj->type];

--- a/src/r_fps.c
+++ b/src/r_fps.c
@@ -60,7 +60,6 @@ typedef struct
 } interpolation_t;
 
 static int numinterpolations = 0;
-boolean pause_interpolations = false;
 
 tic_vars_t tic_vars;
 
@@ -99,11 +98,6 @@ void R_InterpolateView (player_t *player)
 
   if (movement_smooth)
   {
-    if (pause_interpolations)
-    {
-      frac = FRACUNIT;
-    }
-
     viewx = player->mo->PrevX + FixedMul (frac, player->mo->x - player->mo->PrevX);
     viewy = player->mo->PrevY + FixedMul (frac, player->mo->y - player->mo->PrevY);
     viewz = player->prev_viewz + FixedMul (frac, player->viewz - player->prev_viewz);
@@ -317,7 +311,7 @@ void R_DoInterpolations(fixed_t smoothratio)
   if (!movement_smooth)
     return;
 
-  if (smoothratio == FRACUNIT || pause_interpolations)
+  if (smoothratio == FRACUNIT)
   {
     didInterp = false;
     return;

--- a/src/r_fps.h
+++ b/src/r_fps.h
@@ -49,7 +49,6 @@ typedef struct {
 } tic_vars_t;
 
 extern tic_vars_t tic_vars;
-extern boolean pause_interpolations;
 
 void R_InitInterpolation(void);
 void R_InterpolateView(player_t *player);

--- a/src/r_things.c
+++ b/src/r_things.c
@@ -475,7 +475,7 @@ static void R_ProjectSprite (mobj_t* thing, int lightlevel)
    fixed_t tz;
    int width;
 
-   if (movement_smooth && !pause_interpolations)
+   if (movement_smooth)
    {
       fx = thing->PrevX + FixedMul (tic_vars.frac, thing->x - thing->PrevX);
       fy = thing->PrevY + FixedMul (tic_vars.frac, thing->y - thing->PrevY);


### PR DESCRIPTION
This is a follow up from #126

This should keep interpolation for player movement and flats in the state serialization.
The interpolation on monster movement is not there yet.. but I'm not so sure if the increment in size of the state (+ potentially savegame incompatibility) is worth it, to be honest.

I also notice there was a problem with the controls after a load, likely due to the maketic count not being preserved. I believe this is fixed too.

I've also fixed the blinking skull and cleaned up a bit the saving to avoid a memcpy and having to malloc a copy of the state when saving it.

There are more things missing. Like music and the demo playback. I also expect a lot of things could go wrong if a state is loaded with different prboom.cfg configuration, for example. But this is already very nice for things like rewind, like @phcoder mentioned. Thanks