### PR TITLE
Make sure variable declaration is C89 compatible

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -173,3 +173,6 @@ ifneq (,$(findstring msvc,$(platform)))
 else
 INCFLAGS += -include z_zone.h
 endif
+
+# Make sure variable declaration is C89 compatible, for portability
+CFLAGS += -Werror=declaration-after-statement


### PR DESCRIPTION
I suggest to enforce it in the compilation.
Using Makefile.common so the main Makefile can be kept on sync with other libretro projects.