### PR TITLE
retro_run: Don't attempt to run domm lop after exit

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -469,6 +469,7 @@ void retro_run(void)
    {
       environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, NULL);
       I_SafeExit(1);
+      return;
    }
    D_DoomLoop();
    I_UpdateSound();


### PR DESCRIPTION
This fixes crash on exit on 3DS