### PR TITLE
Revert "Do not reallocate or memcpy save state buffer"

### DIFF
--- a/src/g_game.c
+++ b/src/g_game.c
@@ -88,7 +88,7 @@
 #define SAVEGAMESIZE  0x20000
 #define SAVESTRINGSIZE  24
 
-static size_t   savegamesize = 0; // killough
+static size_t   savegamesize = SAVEGAMESIZE; // killough
 static dbool    netdemo;
 static const uint8_t *demobuffer;   /* cph - only used for playback */
 static int demolength; // check for overrun (missing DEMOMARKER)
@@ -126,7 +126,6 @@ int             demover;
 wbstartstruct_t wminfo;               // parms for world map / intermission
 dbool           haswolflevels = FALSE;// jff 4/18/98 wolf levels present
 static uint8_t     *savebuffer;          // CPhipps - static
-static dbool       savestaticbuffer = FALSE;
 int             autorun = FALSE;      // always running?          // phares
 int             totalleveltimes;      // CPhipps - total time for all completed levels
 int		longtics;
@@ -1830,16 +1829,9 @@ void (CheckSaveGame)(size_t size, const char* file, int line)
   size_t pos = save_p - savebuffer;
 
   size += 1024;  // breathing room
-  if (pos+size > savegamesize) {
-    savegamesize += (size+1023) & ~1023;
-    if (savestaticbuffer) {
-      savebuffer = malloc(savegamesize);
-      savestaticbuffer = FALSE;
-    }
-    else
-      savebuffer = realloc(savebuffer, savegamesize);
-    save_p = savebuffer + pos;
-  }
+  if (pos+size > savegamesize)
+    save_p = (savebuffer = realloc(savebuffer,
+           savegamesize += (size+1023) & ~1023)) + pos;
 }
 
 /* killough 3/22/98: form savegame name in one location
@@ -1858,10 +1850,8 @@ void G_SaveGameName(char *name, size_t size, int slot, dbool   demoplayback)
   snprintf (name, size, "%s%c%s%d.dsg", basesavegame, slash, sgn, slot);
 }
 
-
 //
 // Save the game state into the internal savebuffer
-// It'll only reallocate the savebuffer if necessary
 //
 static int G_DoSaveGameToSaveBuffer() {
   char name2[VERSIONSIZE];
@@ -1870,11 +1860,7 @@ static int G_DoSaveGameToSaveBuffer() {
 
   description = savedescription;
 
-  if(!savebuffer || savegamesize < SAVEGAMESIZE) {
-    savegamesize = SAVEGAMESIZE;
-    savebuffer = malloc(savegamesize);
-  }
-  save_p = savebuffer;
+  save_p = savebuffer = malloc(savegamesize);
 
   CheckSaveGame(SAVESTRINGSIZE+VERSIONSIZE+sizeof(uint64_t));
   memcpy (save_p, description, SAVESTRINGSIZE);
@@ -2010,27 +1996,20 @@ bool G_DoSaveGameToBuffer(void *buf, size_t size) {
   if (thinkercap.next == NULL)
     return false;
 
+
   memcpy(description_saved, savedescription, SAVEDESCLEN);
   strcpy(savedescription, "BUFFER");
 
-  // set savebuffer and its size to attempt to save directly into the destination buffer
-  savebuffer = buf;
-  savegamesize = size;
-  savestaticbuffer = TRUE;
-
   length = G_DoSaveGameToSaveBuffer();
 
-  ok     = ((size_t) length <= size);
+  ok = (length > 0 && (size_t) length <= size);
 
-  if (ok && size != (size_t)length) {
-    // initialize the rest with zeroes
-    memset((char*)buf+length, 0, size - length);
-  } else if (savebuffer != NULL && !savestaticbuffer) {
-    // a different savebuffer was allocated, free it
-    free(savebuffer);
-    I_Error("G_DoSaveGameToBuffer: too much data by %d bytes", (int) (length - size));
+  if (ok) {
+    memcpy(buf, savebuffer, length);
+    memset(buf+length, 0, size - length);
   }
-  savestaticbuffer = FALSE;
+
+  free(savebuffer);  // killough
   savebuffer = save_p = NULL;
   memcpy(savedescription, description_saved, SAVEDESCLEN);
 


### PR DESCRIPTION
This hopefully fixes #140

It reverts d8a6b11 (and related changes in 9eb4a04).

Rewind still works and I can't notice a significant difference in performance, though that commit was meant to reduce the memory copies, it seems it didn't have much impact after all.