### PR TITLE
Convert M_LoadDefaultsFile() to VFS file I/O 

### DIFF
--- a/libretro/libretro-common/include/streams/file_stream.h
+++ b/libretro/libretro-common/include/streams/file_stream.h
@@ -81,7 +81,7 @@ char* filestream_gets(RFILE *stream, char *s, size_t len);
 
 int filestream_getc(RFILE *stream);
 
-int filestream_scanf(RFILE *stream, const char* format, ...);
+int filestream_vscanf(RFILE *stream, const char* format, va_list *args);
 
 int filestream_eof(RFILE *stream);
 

--- a/libretro/libretro-common/streams/file_stream.c
+++ b/libretro/libretro-common/streams/file_stream.c
@@ -221,11 +221,11 @@ int filestream_getc(RFILE *stream)
    return EOF;
 }
 
-int filestream_scanf(RFILE *stream, const char* format, ...)
+int filestream_vscanf(RFILE *stream, const char* format, va_list *args)
 {
    char buf[4096];
    char subfmt[64];
-   va_list args;
+   va_list args_copy;
    const char * bufiter = buf;
    int        ret       = 0;
    int64_t startpos     = filestream_tell(stream);
@@ -236,7 +236,12 @@ int filestream_scanf(RFILE *stream, const char* format, ...)
 
    buf[maxlen] = '\0';
 
-   va_start(args, format);
+   /* Have to copy the input va_list here
+    * > Calling va_arg() on 'args' directly would
+    *   cause the va_list to have an indeterminate value
+    *   in the function calling filestream_vscanf(),
+    *   leading to unexpected behaviour */
+   va_copy(args_copy, *args);
 
    while (*format)
    {
@@ -302,7 +307,7 @@ int filestream_scanf(RFILE *stream, const char* format, ...)
          }
          else
          {
-            int v = sscanf(bufiter, subfmt, va_arg(args, void*), &sublen);
+            int v = sscanf(bufiter, subfmt, va_arg(args_copy, void*), &sublen);
             if (v == EOF)
                return EOF;
             if (v != 1)
@@ -327,7 +332,7 @@ int filestream_scanf(RFILE *stream, const char* format, ...)
       }
    }
 
-   va_end(args);
+   va_end(args_copy);
    filestream_seek(stream, startpos+(bufiter-buf),
          RETRO_VFS_SEEK_POSITION_START);
 

--- a/libretro/libretro-common/streams/file_stream_transforms.c
+++ b/libretro/libretro-common/streams/file_stream_transforms.c
@@ -153,7 +153,7 @@ int rfscanf(RFILE * stream, const char * format, ...)
    int result;
    va_list vl;
    va_start(vl, format);
-   result = filestream_scanf(stream, format, vl);
+   result = filestream_vscanf(stream, format, &vl);
    va_end(vl);
    return result;
 }

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -2007,7 +2007,7 @@ bool G_DoSaveGameToBuffer(void *buf, size_t size) {
 
   if (ok) {
     memcpy(buf, savebuffer, length);
-    memset(buf+length, 0, size - length);
+    memset(((char*)buf)+length, 0, size - length);
   }
 
   free(savebuffer);  // killough

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -935,22 +935,23 @@ void M_LoadDefaultsFile (char *file, dbool   basedefault)
 {
   int   i;
   int   len;
-  char  def[80];
-  char  strparm[100];
+  char  def[80] = {0};
+  char  strparm[100] = {0};
   char* newstring = NULL;   // killough
   int   parm;
   dbool   isstring;
   // read the file in, overriding any set defaults
-  FILE *f = fopen (file, "r");
+  RFILE *f = filestream_open (file,
+      RETRO_VFS_FILE_ACCESS_READ,
+      RETRO_VFS_FILE_ACCESS_HINT_NONE);
   if (f)
   {
-    while (!feof(f))
+    while (!rfeof(f))
     {
       isstring = FALSE;
-      if (fscanf(f, "%79s %99[^\n]\n", def, strparm) == 2)
+      if (rfscanf(f, "%79s %99[^\n]\n", def, strparm) == 2)
       {
         //jff 3/3/98 skip lines not starting with an alphanum
-
         if (!isalnum(def[0]))
           continue;
 
@@ -1006,7 +1007,7 @@ void M_LoadDefaultsFile (char *file, dbool   basedefault)
           }
       }
     }
-    fclose(f);
+    filestream_close(f);
   }
   //jff 3/4/98 redundant range checks for hud deleted here
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/libretro/libretro-prboom/commit/af27eb26ef621b02d6054f4423543413e10156f7.

It finishes the job of converting the functions in `m_misc.c` to make use of VFS routines instead of direct file access.

The PR also fixes a long standing build error for older MSVC platforms.