### PR TITLE
Prevent segfault when applying cheats before a level has loaded

### DIFF
--- a/libretro/libretro-common/include/array/rbuf.h
+++ b/libretro/libretro-common/include/array/rbuf.h
@@ -1,0 +1,120 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rbuf.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_ARRAY_RBUF_H__
+#define __LIBRETRO_SDK_ARRAY_RBUF_H__
+
+/*
+ * This file implements stretchy buffers as invented (?) by Sean Barrett.
+ * Based on the implementation from the public domain Bitwise project
+ * by Per Vognsen - https://github.com/pervognsen/bitwise
+ *
+ * It's a super simple type safe dynamic array for C with no need
+ * to predeclare any type or anything.
+ * The first time an element is added, memory for 16 elements are allocated.
+ * Then every time length is about to exceed capacity, capacity is doubled.
+ *
+ * Be careful not to supply modifying statements to the macro arguments.
+ * Something like RBUF_REMOVE(buf, i--); would have unintended results.
+ *
+ * Sample usage:
+ *
+ * mytype_t* buf = NULL;
+ * RBUF_PUSH(buf, some_element);
+ * RBUF_PUSH(buf, other_element);
+ * -- now RBUF_LEN(buf) == 2, buf[0] == some_element, buf[1] == other_element
+ *
+ * -- Free allocated memory:
+ * RBUF_FREE(buf);
+ * -- now buf == NULL, RBUF_LEN(buf) == 0, RBUF_CAP(buf) == 0
+ *
+ * -- Explicitly increase allocated memory and set capacity:
+ * RBUF_FIT(buf, 100);
+ * -- now RBUF_LEN(buf) == 0, RBUF_CAP(buf) == 100
+ * 
+ * -- Resize buffer (does not initialize or zero memory!)
+ * RBUF_RESIZE(buf, 200);
+ * -- now RBUF_LEN(buf) == 200, RBUF_CAP(buf) == 200
+ * 
+ * -- To handle running out of memory:
+ * bool ran_out_of_memory = !RBUF_TRYFIT(buf, 1000);
+ * -- before RESIZE or PUSH. When out of memory, buf will stay unmodified.
+ */
+
+#include <retro_math.h> /* for MAX */
+#include <stdlib.h> /* for malloc, realloc */
+
+#define RBUF__HDR(b) (((struct rbuf__hdr *)(b))-1)
+
+#define RBUF_LEN(b) ((b) ? RBUF__HDR(b)->len : 0)
+#define RBUF_CAP(b) ((b) ? RBUF__HDR(b)->cap : 0)
+#define RBUF_END(b) ((b) + RBUF_LEN(b))
+#define RBUF_SIZEOF(b) ((b) ? RBUF_LEN(b)*sizeof(*b) : 0)
+
+#define RBUF_FREE(b) ((b) ? (free(RBUF__HDR(b)), (b) = NULL) : 0)
+#define RBUF_FIT(b, n) ((size_t)(n) <= RBUF_CAP(b) ? 0 : (*(void**)(&(b)) = rbuf__grow((b), (n), sizeof(*(b)))))
+#define RBUF_PUSH(b, val) (RBUF_FIT((b), 1 + RBUF_LEN(b)), (b)[RBUF__HDR(b)->len++] = (val))
+#define RBUF_POP(b) (b)[--RBUF__HDR(b)->len]
+#define RBUF_RESIZE(b, sz) (RBUF_FIT((b), (sz)), ((b) ? RBUF__HDR(b)->len = (sz) : 0))
+#define RBUF_CLEAR(b) ((b) ? RBUF__HDR(b)->len = 0 : 0)
+#define RBUF_TRYFIT(b, n) (RBUF_FIT((b), (n)), (((b) && RBUF_CAP(b) >= (size_t)(n)) || !(n)))
+#define RBUF_REMOVE(b, idx) memmove((b) + (idx), (b) + (idx) + 1, (--RBUF__HDR(b)->len - (idx)) * sizeof(*(b)))
+
+struct rbuf__hdr
+{
+   size_t len;
+   size_t cap;
+};
+
+#ifdef __GNUC__
+__attribute__((__unused__))
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4505) //unreferenced local function has been removed
+#endif
+static void *rbuf__grow(void *buf,
+      size_t new_len, size_t elem_size)
+{
+   struct rbuf__hdr *new_hdr;
+   size_t new_cap  = MAX(2 * RBUF_CAP(buf), MAX(new_len, 16));
+   size_t new_size = sizeof(struct rbuf__hdr) + new_cap*elem_size;
+   if (buf)
+   {
+      new_hdr      = (struct rbuf__hdr *)realloc(RBUF__HDR(buf), new_size);
+      if (!new_hdr)
+         return buf; /* out of memory, return unchanged */
+   }
+   else
+   {
+      new_hdr      = (struct rbuf__hdr *)malloc(new_size);
+      if (!new_hdr)
+         return NULL; /* out of memory */
+      new_hdr->len = 0;
+   }
+   new_hdr->cap    = new_cap;
+   return new_hdr + 1;
+}
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#endif

--- a/libretro/libretro-common/include/retro_math.h
+++ b/libretro/libretro-common/include/retro_math.h
@@ -1,0 +1,190 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (retro_math.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _LIBRETRO_COMMON_MATH_H
+#define _LIBRETRO_COMMON_MATH_H
+
+#include <stdint.h>
+
+#if defined(_WIN32) && !defined(_XBOX)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#elif defined(_WIN32) && defined(_XBOX)
+#include <Xtl.h>
+#endif
+
+#include <limits.h>
+
+#ifdef _MSC_VER
+#include <compat/msvc.h>
+#endif
+#include <retro_inline.h>
+
+#ifndef M_PI
+#if !defined(USE_MATH_DEFINES)
+#define M_PI 3.14159265358979323846264338327
+#endif
+#endif
+
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+/**
+ * next_pow2:
+ * @v         : initial value
+ *
+ * Get next power of 2 value based on  initial value.
+ *
+ * Returns: next power of 2 value (derived from @v).
+ **/
+static INLINE uint32_t next_pow2(uint32_t v)
+{
+   v--;
+   v |= v >> 1;
+   v |= v >> 2;
+   v |= v >> 4;
+   v |= v >> 8;
+   v |= v >> 16;
+   v++;
+   return v;
+}
+
+/**
+ * prev_pow2:
+ * @v         : initial value
+ *
+ * Get previous power of 2 value based on initial value.
+ *
+ * Returns: previous power of 2 value (derived from @v).
+ **/
+static INLINE uint32_t prev_pow2(uint32_t v)
+{
+   v |= v >> 1;
+   v |= v >> 2;
+   v |= v >> 4;
+   v |= v >> 8;
+   v |= v >> 16;
+   return v - (v >> 1);
+}
+
+/**
+ * clamp:
+ * @v         : initial value
+ *
+ * Get the clamped value based on initial value.
+ *
+ * Returns: clamped value (derived from @v).
+ **/
+static INLINE float clamp_value(float v, float min, float max)
+{
+   return v <= min ? min : v >= max ? max : v;
+}
+
+/**
+ * saturate_value:
+ * @v         : initial value
+ *
+ * Get the clamped 0.0-1.0 value based on initial value.
+ *
+ * Returns: clamped 0.0-1.0 value (derived from @v).
+ **/
+static INLINE float saturate_value(float v)
+{
+   return clamp_value(v, 0.0f, 1.0f);
+}
+
+/**
+ * dot_product:
+ * @a         : left hand vector value
+ * @b         : right hand vector value
+ *
+ * Get the dot product of the two passed in vectors.
+ *
+ * Returns: dot product value (derived from @a and @b).
+ **/
+static INLINE float dot_product(const float* a, const float* b) 
+{
+   return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
+}
+
+/**
+ * convert_rgb_to_yxy:
+ * @rgb         : in RGB colour space value
+ * @Yxy         : out Yxy colour space value
+ *
+ * Convert from RGB colour space to Yxy colour space.
+ *
+ * Returns: Yxy colour space value (derived from @rgb).
+ **/
+static INLINE void convert_rgb_to_yxy(const float* rgb, float* Yxy) 
+{
+   float inv;
+   float xyz[3];
+   float one[3]        = {1.0, 1.0, 1.0};
+   float rgb_xyz[3][3] = {
+      {0.4124564, 0.3575761, 0.1804375},
+      {0.2126729, 0.7151522, 0.0721750},
+      {0.0193339, 0.1191920, 0.9503041}
+   };
+
+   xyz[0]              = dot_product(rgb_xyz[0], rgb);
+   xyz[1]              = dot_product(rgb_xyz[1], rgb);
+   xyz[2]              = dot_product(rgb_xyz[2], rgb);
+
+   inv                 = 1.0f / dot_product(xyz, one);
+   Yxy[0]              = xyz[1]; 
+   Yxy[1]              = xyz[0] * inv;
+   Yxy[2]              = xyz[1] * inv;
+}
+ 
+/**
+ * convert_yxy_to_rgb:
+ * @rgb         : in Yxy colour space value
+ * @Yxy         : out rgb colour space value
+ *
+ * Convert from Yxy colour space to rgb colour space.
+ *
+ * Returns: rgb colour space value (derived from @Yxy).
+ **/
+static INLINE void convert_yxy_to_rgb(const float* Yxy, float* rgb)
+{
+   float xyz[3];
+   float xyz_rgb[3][3] = {
+      {3.2404542, -1.5371385, -0.4985314},
+      {-0.9692660, 1.8760108,  0.0415560},
+      {0.0556434, -0.2040259, 1.0572252}
+   };
+   xyz[0]              = Yxy[0] * Yxy[1] / Yxy[2];
+   xyz[1]              = Yxy[0];
+   xyz[2]              = Yxy[0] * (1.0 - Yxy[1] - Yxy[2]) / Yxy[2];
+
+   rgb[0]              = dot_product(xyz_rgb[0], xyz);
+   rgb[1]              = dot_product(xyz_rgb[1], xyz);
+   rgb[2]              = dot_product(xyz_rgb[2], xyz);
+}
+
+#endif

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1494,7 +1494,6 @@ void D_DoomDeinit(void)
   V_DestroyUnusedTrueColorPalettes();
   R_FlushAllPatches();
   P_Deinit();
-  Z_Close();
 }
 
 //

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -112,6 +112,10 @@ void Z_Close(void)
 
 bool Z_Init(void)
 {
+   unsigned i;
+   for (i = 0; i < PU_MAX; i++)
+      blockbytag[i] = NULL;
+
    return true;
 }
 


### PR DESCRIPTION
At present, the core will segfault if the user attempts to apply cheats before starting a game (i.e. in the main menu). This happens most notably when using RetroArch with `Auto-Apply Cheats During Game Load` enabled, since the core will crash immediately on load content. The segfault occurs because applying cheats requires access to certain objects that are not initialised until a level is actually loaded.

This PR fixes the issue by caching any cheat codes set while the core is in an invalid state, and applying them at the next available opportunity.

