### PR TITLE
'MEMORY_LOW' improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DEBUG ?= 0
 STATIC_LINKING ?= 0
 WANT_FLUIDSYNTH ?= 0
+HAVE_LOW_MEMORY ?= 0
 
 ifeq ($(platform),)
 platform = unix
@@ -233,8 +234,9 @@ else ifeq ($(platform), ps2)
    TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
    CC = mips64r5900el-ps2-elf-gcc$(EXE_EXT)
    AR = mips64r5900el-ps2-elf-ar$(EXE_EXT)
-   CFLAGS += -DHAVE_STRLWR -DPS2 -G0 -ffast-math -DABGR1555 -DNO_FAST_SQRT -DMEMORY_LOW
-	STATIC_LINKING = 1
+   CFLAGS += -DHAVE_STRLWR -DPS2 -G0 -ffast-math -DABGR1555 -DNO_FAST_SQRT
+   STATIC_LINKING = 1
+   HAVE_LOW_MEMORY = 1
 # PSP1
 else ifeq ($(platform), psp1)
 	EXT=a
@@ -283,8 +285,9 @@ else ifeq ($(platform), ngc)
    TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   CFLAGS += -DGEKKO -DHW_DOL -mogc -mcpu=750 -meabi -mhard-float -DMEMORY_LOW
+   CFLAGS += -DGEKKO -DHW_DOL -mogc -mcpu=750 -meabi -mhard-float
    STATIC_LINKING = 1
+   HAVE_LOW_MEMORY = 1
 
 else ifeq ($(platform), wii)
    EXT=a
@@ -361,6 +364,7 @@ else ifeq ($(platform), miyoo)
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=libretro/link.T -Wl,-no-undefined
    CFLAGS += -ffast-math -march=armv5te -mtune=arm926ej-s -fomit-frame-pointer
+   HAVE_LOW_MEMORY = 1
 
 # Windows MSVC 2003 Xbox 1
 else ifeq ($(platform), xbox1_msvc2003)
@@ -617,6 +621,10 @@ CFLAGS += -DHAVE_LIBMAD -DMUSIC_SUPPORT
 
 ifeq ($(WANT_FLUIDSYNTH), 1)
 CFLAGS += -DHAVE_LIBFLUIDSYNTH
+endif
+
+ifeq ($(HAVE_LOW_MEMORY), 1)
+CFLAGS += -DMEMORY_LOW
 endif
 
 ifeq ($(DEBUG), 1)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1761,40 +1761,6 @@ void I_Init(void)
    R_InitInterpolation();
 }
 
-/*
-* I_Filelength
-*
-* Return length of an open file.
-*/
-
-int I_Filelength(int handle)
-{
-   struct stat   fileinfo;
-   if (fstat(handle,&fileinfo) == -1)
-   {
-      I_Error("I_Filelength: %s",strerror(errno));
-      return 0;
-   }
-   return fileinfo.st_size;
-}
-
-void I_Read(int fd, void* vbuf, size_t sz)
-{
-   unsigned char* buf = vbuf;
-
-   while (sz)
-   {
-      int rc = read(fd,buf,sz);
-      if (rc <= 0)
-      {
-         I_Error("I_Read: read failed: %s", rc ? strerror(errno) : "EOF");
-         break;
-      }
-      sz  -= rc;
-      buf += rc;
-   }
-}
-
 void R_InitInterpolation(void)
 {
   struct retro_system_av_info info;

--- a/src/i_system.h
+++ b/src/i_system.h
@@ -59,7 +59,4 @@ const char *I_DoomExeDir(void); // killough 2/16/98: path to executable's dir
 dbool   HasTrailingSlash(const char* dn);
 char* I_FindFile(const char* wfname, const char* ext);
 
-/* cph 2001/11/18 - Move W_Filelength to i_system.c */
-int I_Filelength(int handle);
-
 #endif

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -55,6 +55,7 @@
 just forward declare the prototype */
 int64_t rfread(void* buffer,
    size_t elem_size, size_t elem_count, RFILE* stream);
+int64_t rfseek(RFILE* stream, int64_t offset, int origin);
 
 //
 // GLOBALS
@@ -136,24 +137,13 @@ static void W_AddFile(wadfile_info_t *wadfile)
    filelump_t  *fileinfo = NULL;
    filelump_t *fileinfo2free=NULL; //killough
    filelump_t singleinfo;
-#ifndef MEMORY_LOW
-   struct stat statbuf;
-#endif
 
    // open the file and add to directory
-
-#ifdef MEMORY_LOW
-   wadfile->handle = open(wadfile->name, O_RDONLY | O_BINARY);
-
-   if (wadfile->handle == -1)
-#else
-      //precache into memory instead of reading from disk
-      wadfile->handle = filestream_open(wadfile->name,
-		      RETRO_VFS_FILE_ACCESS_READ,
-		      RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   wadfile->handle = filestream_open(wadfile->name,
+         RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
    if (!wadfile->handle)
-#endif
    {
       if (  strlen(wadfile->name)<=4 ||      // add error check -- killough
             (strcasecmp(wadfile->name+strlen(wadfile->name)-4 , ".lmp" ) &&
@@ -164,11 +154,11 @@ static void W_AddFile(wadfile_info_t *wadfile)
    }
 
 #ifndef MEMORY_LOW
-   stat(wadfile->name, &statbuf);
-   wadfile->length = statbuf.st_size;
-   wadfile->data = malloc(statbuf.st_size);
-   if ( rfread(wadfile->data, statbuf.st_size, 1, wadfile->handle) != 1)
-     I_Error("W_AddFile: couldn't read wad data");
+   // precache into memory instead of reading from disk
+   wadfile->length = filestream_get_size(wadfile->handle);
+   wadfile->data = malloc(wadfile->length);
+   if ( rfread(wadfile->data, wadfile->length, 1, wadfile->handle) != 1)
+      I_Error("W_AddFile: couldn't read wad data");
 #endif
 
    //jff 8/3/98 use logical output routine
@@ -186,7 +176,7 @@ static void W_AddFile(wadfile_info_t *wadfile)
       fileinfo = &singleinfo;
       singleinfo.filepos = 0;
 #ifdef MEMORY_LOW
-      singleinfo.size = LONG(I_Filelength(wadfile->handle));
+      singleinfo.size = LONG(filestream_get_size(wadfile->handle));
 #else
       singleinfo.size = wadfile->length;
 #endif
@@ -197,7 +187,8 @@ static void W_AddFile(wadfile_info_t *wadfile)
    {
       // WAD file
 #ifdef MEMORY_LOW
-      I_Read(wadfile->handle, &header, sizeof(header));
+      if (rfread(&header, sizeof(header), 1, wadfile->handle) <= 0)
+         I_Error("W_AddFile: read failed");
 #else
       memcpy(&header, wadfile->data, sizeof(header));
 #endif
@@ -209,8 +200,9 @@ static void W_AddFile(wadfile_info_t *wadfile)
       length = header.numlumps*sizeof(filelump_t);
       fileinfo2free = fileinfo = malloc(length);    // killough
 #ifdef MEMORY_LOW
-      lseek(wadfile->handle, header.infotableofs, SEEK_SET);
-      I_Read(wadfile->handle, fileinfo, length);
+      rfseek(wadfile->handle, header.infotableofs, SEEK_SET);
+      if (rfread(fileinfo, length, 1, wadfile->handle) <= 0)
+         I_Error("W_AddFile: read failed");
 #else
       memcpy(fileinfo, &wadfile->data[header.infotableofs], length);
 #endif
@@ -500,10 +492,8 @@ void W_Exit(void)
    {
       if (wadfiles[i].handle)
       {
-#ifdef MEMORY_LOW
-         close(wadfiles[i].handle);
-#else
          filestream_close(wadfiles[i].handle);
+#ifndef MEMORY_LOW
          free(wadfiles[i].data);
          wadfiles[i].data = NULL;
 #endif
@@ -521,10 +511,8 @@ void W_ReleaseAllWads(void)
    {
       if(wadfiles[i].handle)
       {
-#ifdef MEMORY_LOW
-         close(wadfiles[i].handle);
-#else
          filestream_close(wadfiles[i].handle);
+#ifndef MEMORY_LOW
          free(wadfiles[i].data);
          wadfiles[i].data = NULL;
 #endif
@@ -565,8 +553,9 @@ void W_ReadLump(int lump, void *dest)
       if (l->wadfile)
       {
 #ifdef MEMORY_LOW
-         lseek(l->wadfile->handle, l->position, SEEK_SET);
-         I_Read(l->wadfile->handle, dest, l->size);
+         rfseek(l->wadfile->handle, l->position, SEEK_SET);
+         if (rfread(dest, l->size, 1, l->wadfile->handle) <= 0)
+            I_Error("W_ReadLump: read failed");
 #else
          memcpy(dest, &l->wadfile->data[l->position], l->size);
 #endif

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -87,10 +87,8 @@ typedef enum {
 typedef struct {
   const char* name;
   wad_source_t src;
-#ifdef MEMORY_LOW
-  int handle;
-#else
   RFILE* handle;
+#ifndef MEMORY_LOW
   unsigned char *data;
   int position;
   int length;

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -93,8 +93,14 @@ static const size_t HEADER_SIZE = (sizeof(memblock_t)+CHUNK_SIZE-1) & ~(CHUNK_SI
 static memblock_t *blockbytag[PU_MAX];
 
 // 0 means unlimited, any other value is a hard limit
-//static int memory_size = 8192*1024;
+#ifdef MEMORY_LOW
+/* Set a limit of 12 MB (previous default was
+ * 8 MB, but this reduces runtime performance
+ * to an unacceptable level) */
+static int memory_size = 12*1024*1024;
+#else
 static int memory_size = 0;
+#endif
 static int free_memory = 0;
 
 


### PR DESCRIPTION
This small PR is made in response to #162. It makes the following changes to the core:

- The `MEMORY_LOW` code path for WAD file handling (where the WAD is loaded on demand instead of being cached entirely in RAM) has been modified to make use of VFS routines instead of direct file access
- When `MEMORY_LOW` is defined, the `z_zone` purge limit is set to 12 MB (i.e. the internal memory handler will start to free blocks where possible once memory usage exceeds this value). Previously (and without defining `MEMORY_LOW`), the internal cache will *never* be purged (harmless on most platforms, but undesirable on RAM starved devices). Note that a (commented out/unused) purge limit of 8 MB was already present in the code, but a limit this low causes significant stuttering when loading assets (12 MB seems to work fine)
- `MEMORY_LOW` is now also defined for Miyoo platforms, since a number of these devices only have 32 MB of RAM

