### PR TITLE
'MEMORY_LOW' platforms: Enable configuration of purge limit + fix loading of Hacx WAD

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -586,6 +586,16 @@ static void update_variables(bool startup)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       analog_deadzone = (int)(atoi(var.value) * 0.01f * ANALOG_RANGE);
+
+#if defined(MEMORY_LOW)
+   var.key = "prboom-purge_limit";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int purge_limit = atoi(var.value) * 1024 * 1024;
+      Z_SetPurgeLimit(purge_limit);
+   }
+#endif
 }
 
 void I_SafeExit(int rc);

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -29,7 +29,7 @@ extern "C" {
 struct retro_core_option_definition option_defs_us[] = {
    {
       "prboom-resolution",
-      "Internal resolution (restart)",
+      "Internal Resolution (Restart)",
       "Configure the resolution. Requires a restart.",
       {
          { "320x200",   NULL },
@@ -46,7 +46,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "prboom-mouse_on",
-      "Mouse active when using Gamepad",
+      "Mouse Active When Using Gamepad",
       "Allows you to use mouse inputs even when User 1's device type isn't set to 'RetroKeyboard/Mouse'.",
       {
          { "disabled", NULL },
@@ -57,7 +57,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "prboom-find_recursive_on",
-      "Look on parent folders for IWADs",
+      "Look on Parent Folders for IWADs",
       "Scans parent folders for IWADs. NOTE: You need to disable this if you want to run SIGIL.",
       {
          { "disabled", NULL },
@@ -79,7 +79,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "prboom-analog_deadzone",
-      "Analog Deadzone (percent)",
+      "Analog Deadzone (Percent)",
       "Sets the deadzone of the gamepad analog sticks when the input device type is set to 'Gamepad Modern'.",
       {
          { "0",  NULL },
@@ -93,6 +93,26 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "15"
    },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      "Cache Size",
+      "Sets a limit on the size of the memory pool used to cache game assets. Small values may cause stuttering when navigating large maps.",
+      {
+         { "8",   "8 MB" },
+         { "12",  "12 MB" },
+         { "16",  "16 MB" },
+         { "24",  "24 MB" },
+         { "32",  "32 MB" },
+         { "48",  "48 MB" },
+         { "64",  "64 MB" },
+         { "128", "128 MB" },
+         { "256", "256 MB" },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -549,16 +549,19 @@ void W_ReadLump(int lump, void *dest)
 {
   lumpinfo_t *l = lumpinfo + lump;
 
-    {
-      if (l->wadfile)
-      {
+   if (l->wadfile)
+   {
 #ifdef MEMORY_LOW
+      if (l->size > 0)
+      {
          rfseek(l->wadfile->handle, l->position, SEEK_SET);
          if (rfread(dest, l->size, 1, l->wadfile->handle) <= 0)
             I_Error("W_ReadLump: read failed");
-#else
-         memcpy(dest, &l->wadfile->data[l->position], l->size);
-#endif
       }
-    }
+      else
+         I_Error("W_ReadLump: attempt to read lump of zero size");
+#else
+      memcpy(dest, &l->wadfile->data[l->position], l->size);
+#endif
+   }
 }

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -94,10 +94,12 @@ static memblock_t *blockbytag[PU_MAX];
 
 // 0 means unlimited, any other value is a hard limit
 #ifdef MEMORY_LOW
-/* Set a limit of 12 MB (previous default was
- * 8 MB, but this reduces runtime performance
- * to an unacceptable level) */
-static int memory_size = 12*1024*1024;
+/* Set a default limit of 16 MB; smaller values
+ * will cause performance issues when rendering
+ * large levels */
+static int memory_size = 16*1024*1024;
+/* Set a minimum 'limited' size of 8 MB */
+#define MIN_MEMORY_SIZE (8*1024*1024)
 #else
 static int memory_size = 0;
 #endif
@@ -334,4 +336,21 @@ char *Z_Strdup(const char *s, int tag, void **user)
 
 void Z_CheckHeap(void)
 {
+}
+
+void Z_SetPurgeLimit(int size)
+{
+   /* Only memory-starved platforms apply
+    * a purge limit */
+#ifdef MEMORY_LOW
+   if (size == memory_size)
+      return;
+
+   if (size < MIN_MEMORY_SIZE)
+   {
+      I_Error("Z_SetPurgeLimit: Attempted to set a purge limit of less than 8 MB");
+      size = MIN_MEMORY_SIZE;
+   }
+   memory_size = size;
+#endif
 }

--- a/src/z_zone.h
+++ b/src/z_zone.h
@@ -75,6 +75,7 @@ void *(Z_Realloc)(void *p, size_t n, int tag, void **user DA(const char *, int))
 char *(Z_Strdup)(const char *s, int tag, void **user DA(const char *, int));
 void (Z_CheckHeap)(DAC(const char *,int));   // killough 3/22/98: add file/line info
 void Z_DumpHistory(char *);
+void Z_SetPurgeLimit(int size);
 
 // Remove all definitions before including system definitions
 


### PR DESCRIPTION
Following feedback from #162, this PR makes the following changes to the `MEMORY_LOW` codepath:

- The `z_zone` purge limit can now be set via a new `Cache Size` core option, with a default value of 16 MB (the previous hardcoded value of 12 MB causes performance issues when navigating large levels - but we still need this setting for devices with 32 MB of RAM)
- Loading of the Hacx Doom II total conversion mod has been fixed (the WAD is somewhat badly behaved, resulting in attempts to read lumps of zero size - which ended up causing a divide by zero error)