### PR TITLE
Update core options to v2 and sync with Crowdin

### DIFF
--- a/.github/workflows/crowdin_prep.yml
+++ b/.github/workflows/crowdin_prep.yml
@@ -1,0 +1,33 @@
+# Prepare source texts & upload them to Crowdin
+
+name: Crowdin Source Texts Upload
+
+# on change to the English texts
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'libretro/libretro_core_options.h'
+
+jobs:
+  upload_source_file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Upload Source
+        shell: bash
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
+        run: |
+          python3 intl/upload_workflow.py $CROWDIN_API_KEY "libretro-prboom" "libretro/libretro_core_options.h"

--- a/.github/workflows/crowdin_translate.yml
+++ b/.github/workflows/crowdin_translate.yml
@@ -1,0 +1,46 @@
+# Download translations form Crowdin & Recreate libretro_core_options_intl.h
+
+name: Crowdin Translation Integration
+
+on:
+  schedule:
+  # please choose a random time & weekday to avoid all repos synching at the same time
+    - cron: '10 16 * * 5'  # Fridays at 4:10 PM, UTC
+
+jobs:
+  create_intl_file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+
+      - name: Create intl file
+        shell: bash
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
+        run: |
+          python3 intl/download_workflow.py $CROWDIN_API_KEY "libretro-prboom" "libretro/libretro_core_options_intl.h"
+
+      - name: Commit files
+        run: |
+          git config --local user.email "github-actions@github.com"
+          git config --local user.name "github-actions[bot]"
+          git add intl/download_workflow.py "libretro/libretro_core_options_intl.h"
+          git commit -m "Fetch translations & Recreate libretro_core_options_intl.h"
+
+      - name: GitHub Push
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/intl/.gitignore
+++ b/intl/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+crowdin-cli.jar
+*.h
+*.json

--- a/intl/core_option_regex.py
+++ b/intl/core_option_regex.py
@@ -1,0 +1,95 @@
+import re
+
+# 0: full struct; 1: up to & including first []; 2: content between first {}
+p_struct = re.compile(r'(struct\s*[a-zA-Z0-9_\s]+\[])\s*'
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+)\s*)*'
+                      r'=\s*'  # =
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+)\s*)*'
+                      r'{((?:.|[\r\n])*?)\{\s*NULL,\s*NULL,\s*NULL\s*(?:.|[\r\n])*?},?(?:.|[\r\n])*?};')  # captures full struct, it's beginning and it's content
+# 0: type name[]; 1: type; 2: name
+p_type_name = re.compile(r'(retro_core_option_[a-zA-Z0-9_]+)\s*'
+                         r'(option_cats([a-z_]{0,8})|option_defs([a-z_]{0,8}))\s*\[]')
+# 0: full option; 1: key; 2: description; 3: additional info; 4: key/value pairs
+p_option = re.compile(r'{\s*'  # opening braces
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'(\".*?\"|'  # key start; group 1
+                      r'[a-zA-Z0-9_]+\s*\((?:.|[\r\n])*?\)|'
+                      r'[a-zA-Z0-9_]+\s*\[(?:.|[\r\n])*?]|'
+                      r'[a-zA-Z0-9_]+\s*\".*?\")\s*'  # key end
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'(\".*?\")\s*'  # description; group 2
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'((?:'  # group 3
+                      r'(?:NULL|\"(?:.|[\r\n])*?\")\s*'  # description in category, info, info in category, category
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',?\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r')+)'
+                      r'(?:'  # defs only start
+                      r'{\s*'  # opening braces
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'((?:'  # key/value pairs start; group 4
+                      r'{\s*'  # opening braces
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'(?:NULL|\".*?\")\s*'  # option key
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'(?:NULL|\".*?\")\s*'  # option value
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'}\s*'  # closing braces
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',?\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r')*)'  # key/value pairs end
+                      r'}\s*'  # closing braces
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',?\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r'(?:'  # defaults start
+                      r'(?:NULL|\".*?\")\s*'  # default value
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r',?\s*'  # comma
+                      r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                      r')*'  # defaults end
+                      r')?'  # defs only end
+                      r'},')  # closing braces
+# analyse option group 3
+p_info = re.compile(r'(NULL|\"(?:.|[\r\n])*?\")\s*'  # description in category, info, info in category, category
+                    r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                    r',')
+p_info_cat = re.compile(r'(NULL|\"(?:.|[\r\n])*?\")')
+# analyse option group 4
+p_key_value = re.compile(r'{\s*'  # opening braces
+                         r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                         r'(NULL|\".*?\")\s*'  # option key; 1
+                         r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                         r',\s*'  # comma
+                         r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                         r'(NULL|\".*?\")\s*'  # option value; 2
+                         r'(?:(?:\/\*(?:.|[\r\n])*?\*\/|\/\/.*[\r\n]+|#.*[\r\n]+)\s*)*'
+                         r'}')
+
+p_masked = re.compile(r'([A-Z_][A-Z0-9_]+)\s*(\"(?:"\s*"|\\\s*|.)*\")')
+
+p_intl = re.compile(r'(struct retro_core_option_definition \*option_defs_intl\[RETRO_LANGUAGE_LAST]) = {'
+                    r'((?:.|[\r\n])*?)};')
+p_set = re.compile(r'static INLINE void libretro_set_core_options\(retro_environment_t environ_cb\)'
+                   r'(?:.|[\r\n])*?};?\s*#ifdef __cplusplus\s*}\s*#endif')
+
+p_yaml = re.compile(r'"project_id": "[0-9]+".*\s*'
+                    r'"api_token": "([a-zA-Z0-9]+)".*\s*'
+                    r'"base_path": "\./intl".*\s*'
+                    r'"base_url": "https://api\.crowdin\.com".*\s*'
+                    r'"preserve_hierarchy": true.*\s*'
+                    r'"files": \[\s*'
+                    r'\{\s*'
+                    r'"source": "/_us/\*\.json",.*\s*'
+                    r'"translation": "/_%two_letters_code%/%original_file_name%",.*\s*'
+                    r'"skip_untranslated_strings": true.*\s*'
+                    r'},\s*'
+                    r']')

--- a/intl/core_option_translation.py
+++ b/intl/core_option_translation.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+
+"""Core options text extractor
+
+The purpose of this script is to set up & provide functions for automatic generation of 'libretro_core_options_intl.h'
+from 'libretro_core_options.h' using translations from Crowdin.
+
+Both v1 and v2 structs are supported. It is, however, recommended to convert v1 files to v2 using the included
+'v1_to_v2_converter.py'.
+
+Usage:
+python3 path/to/core_option_translation.py "path/to/where/libretro_core_options.h & libretro_core_options_intl.h/are" "core_name"
+
+This script will:
+1.) create key words for & extract the texts from libretro_core_options.h & save them into intl/_us/core_options.h
+2.) do the same for any present translations in libretro_core_options_intl.h, saving those in their respective folder
+"""
+import core_option_regex as cor
+import re
+import os
+import sys
+import json
+import urllib.request as req
+import shutil
+
+# LANG_CODE_TO_R_LANG = {'_ar': 'RETRO_LANGUAGE_ARABIC',
+#                        '_ast': 'RETRO_LANGUAGE_ASTURIAN',
+#                        '_chs': 'RETRO_LANGUAGE_CHINESE_SIMPLIFIED',
+#                        '_cht': 'RETRO_LANGUAGE_CHINESE_TRADITIONAL',
+#                        '_cs': 'RETRO_LANGUAGE_CZECH',
+#                        '_cy': 'RETRO_LANGUAGE_WELSH',
+#                        '_da': 'RETRO_LANGUAGE_DANISH',
+#                        '_de': 'RETRO_LANGUAGE_GERMAN',
+#                        '_el': 'RETRO_LANGUAGE_GREEK',
+#                        '_eo': 'RETRO_LANGUAGE_ESPERANTO',
+#                        '_es': 'RETRO_LANGUAGE_SPANISH',
+#                        '_fa': 'RETRO_LANGUAGE_PERSIAN',
+#                        '_fi': 'RETRO_LANGUAGE_FINNISH',
+#                        '_fr': 'RETRO_LANGUAGE_FRENCH',
+#                        '_gl': 'RETRO_LANGUAGE_GALICIAN',
+#                        '_he': 'RETRO_LANGUAGE_HEBREW',
+#                        '_hu': 'RETRO_LANGUAGE_HUNGARIAN',
+#                        '_id': 'RETRO_LANGUAGE_INDONESIAN',
+#                        '_it': 'RETRO_LANGUAGE_ITALIAN',
+#                        '_ja': 'RETRO_LANGUAGE_JAPANESE',
+#                        '_ko': 'RETRO_LANGUAGE_KOREAN',
+#                        '_nl': 'RETRO_LANGUAGE_DUTCH',
+#                        '_oc': 'RETRO_LANGUAGE_OCCITAN',
+#                        '_pl': 'RETRO_LANGUAGE_POLISH',
+#                        '_pt_br': 'RETRO_LANGUAGE_PORTUGUESE_BRAZIL',
+#                        '_pt_pt': 'RETRO_LANGUAGE_PORTUGUESE_PORTUGAL',
+#                        '_ru': 'RETRO_LANGUAGE_RUSSIAN',
+#                        '_sk': 'RETRO_LANGUAGE_SLOVAK',
+#                        '_sv': 'RETRO_LANGUAGE_SWEDISH',
+#                        '_tr': 'RETRO_LANGUAGE_TURKISH',
+#                        '_uk': 'RETRO_LANGUAGE_UKRAINIAN',
+#                        '_us': 'RETRO_LANGUAGE_ENGLISH',
+#                        '_vn': 'RETRO_LANGUAGE_VIETNAMESE'}
+
+# these are handled by RetroArch directly - no need to include them in core translations
+ON_OFFS = {'"enabled"', '"disabled"', '"true"', '"false"', '"on"', '"off"'}
+
+
+def remove_special_chars(text: str, char_set=0, allow_non_ascii=False) -> str:
+   """Removes special characters from a text.
+
+   :param text: String to be cleaned.
+   :param char_set: 0 -> remove all ASCII special chars except for '_' & 'space' (default)
+                    1 -> remove invalid chars from file names
+   :param allow_non_ascii: False -> all non-ascii characters will be removed (default)
+                           True -> non-ascii characters will be passed through
+   :return: Clean text.
+   """
+   command_chars = [chr(unicode) for unicode in tuple(range(0, 32)) + (127,)]
+   special_chars = ([chr(unicode) for unicode in tuple(range(33, 48)) + tuple(range(58, 65)) + tuple(range(91, 95))
+                     + (96,) + tuple(range(123, 127))],
+                    ('\\', '/', ':', '*', '?', '"', '<', '>', '|', '#', '%',
+                     '&', '{', '}', '$', '!', '¸', "'", '@', '+', '='))
+   res = text if allow_non_ascii \
+      else text.encode('ascii', errors='ignore').decode('unicode-escape')
+
+   for cm in command_chars:
+      res = res.replace(cm, '_')
+   for sp in special_chars[char_set]:
+      res = res.replace(sp, '_')
+   while res.startswith('_'):
+      res = res[1:]
+   while res.endswith('_'):
+      res = res[:-1]
+   return res
+
+
+def clean_file_name(file_name: str) -> str:
+   """Removes characters which might make file_name inappropriate for files on some OS.
+
+   :param file_name: File name to be cleaned.
+   :return: The clean file name.
+   """
+   file_name = remove_special_chars(file_name, 1)
+   file_name = re.sub(r'__+', '_', file_name.replace(' ', '_'))
+   return file_name
+
+
+def get_struct_type_name(decl: str) -> tuple:
+   """ Returns relevant parts of the struct declaration:
+   type, name of the struct and the language appendix, if present.
+   :param decl: The struct declaration matched by cor.p_type_name.
+   :return: Tuple, e.g.: ('retro_core_option_definition', 'option_defs_us', '_us')
+   """
+   struct_match = cor.p_type_name.search(decl)
+   if struct_match:
+      if struct_match.group(3):
+         struct_type_name = struct_match.group(1, 2, 3)
+         return struct_type_name
+      elif struct_match.group(4):
+         struct_type_name = struct_match.group(1, 2, 4)
+         return struct_type_name
+      else:
+         struct_type_name = struct_match.group(1, 2)
+         return struct_type_name
+   else:
+      raise ValueError(f'No or incomplete struct declaration: {decl}!\n'
+                       'Please make sure all structs are complete, including the type and name declaration.')
+
+
+def is_viable_non_dupe(text: str, comparison) -> bool:
+   """text must be longer than 2 ('""'), not 'NULL' and not in comparison.
+
+   :param text: String to be tested.
+   :param comparison: Dictionary or set to search for text in.
+   :return: bool
+   """
+   return 2 < len(text) and text != 'NULL' and text not in comparison
+
+
+def is_viable_value(text: str) -> bool:
+   """text must be longer than 2 ('""'), not 'NULL' and text.lower() not in
+   {'"enabled"', '"disabled"', '"true"', '"false"', '"on"', '"off"'}.
+
+   :param text: String to be tested.
+   :return: bool
+   """
+   return 2 < len(text) and text != 'NULL' and text.lower() not in ON_OFFS
+
+
+def create_non_dupe(base_name: str, opt_num: int, comparison) -> str:
+   """Makes sure base_name is not in comparison, and if it is it's renamed.
+
+   :param base_name: Name to check/make unique.
+   :param opt_num: Number of the option base_name belongs to, used in making it unique.
+   :param comparison: Dictionary or set to search for base_name in.
+   :return: Unique name.
+   """
+   h = base_name
+   if h in comparison:
+      n = 0
+      h = h + '_O' + str(opt_num)
+      h_end = len(h)
+      while h in comparison:
+         h = h[:h_end] + '_' + str(n)
+         n += 1
+   return h
+
+
+def get_texts(text: str) -> dict:
+   """Extracts the strings, which are to be translated/are the translations,
+   from text and creates macro names for them.
+
+   :param text: The string to be parsed.
+   :return: Dictionary of the form { '_<lang>': { 'macro': 'string', ... }, ... }.
+   """
+   # all structs: group(0) full struct, group(1) beginning, group(2) content
+   structs = cor.p_struct.finditer(text)
+   hash_n_string = {}
+   just_string = {}
+   for struct in structs:
+      struct_declaration = struct.group(1)
+      struct_type_name = get_struct_type_name(struct_declaration)
+      if 3 > len(struct_type_name):
+         lang = '_us'
+      else:
+         lang = struct_type_name[2]
+      if lang not in just_string:
+         hash_n_string[lang] = {}
+         just_string[lang] = set()
+
+      is_v2 = False
+      pre_name = ''
+      p = cor.p_info
+      if 'retro_core_option_v2_definition' == struct_type_name[0]:
+         is_v2 = True
+      elif 'retro_core_option_v2_category' == struct_type_name[0]:
+         pre_name = 'CATEGORY_'
+         p = cor.p_info_cat
+
+      struct_content = struct.group(2)
+      # 0: full option; 1: key; 2: description; 3: additional info; 4: key/value pairs
+      struct_options = cor.p_option.finditer(struct_content)
+      for opt, option in enumerate(struct_options):
+         # group 1: key
+         if option.group(1):
+            opt_name = pre_name + option.group(1)
+            # no special chars allowed in key
+            opt_name = remove_special_chars(opt_name).upper().replace(' ', '_')
+         else:
+            raise ValueError(f'No option name (key) found in struct {struct_type_name[1]} option {opt}!')
+
+         # group 2: description0
+         if option.group(2):
+            desc0 = option.group(2)
+            if is_viable_non_dupe(desc0, just_string[lang]):
+               just_string[lang].add(desc0)
+               m_h = create_non_dupe(re.sub(r'__+', '_', f'{opt_name}_LABEL'), opt, hash_n_string[lang])
+               hash_n_string[lang][m_h] = desc0
+         else:
+            raise ValueError(f'No label found in struct {struct_type_name[1]} option {option.group(1)}!')
+
+         # group 3: desc1, info0, info1, category
+         if option.group(3):
+            infos = option.group(3)
+            option_info = p.finditer(infos)
+            if is_v2:
+               desc1 = next(option_info).group(1)
+               if is_viable_non_dupe(desc1, just_string[lang]):
+                  just_string[lang].add(desc1)
+                  m_h = create_non_dupe(re.sub(r'__+', '_', f'{opt_name}_LABEL_CAT'), opt, hash_n_string[lang])
+                  hash_n_string[lang][m_h] = desc1
+               last = None
+               m_h = None
+               for j, info in enumerate(option_info):
+                  last = info.group(1)
+                  if is_viable_non_dupe(last, just_string[lang]):
+                     just_string[lang].add(last)
+                     m_h = create_non_dupe(re.sub(r'__+', '_', f'{opt_name}_INFO_{j}'), opt,
+                                           hash_n_string[lang])
+                     hash_n_string[lang][m_h] = last
+               if last in just_string[lang]:  # category key should not be translated
+                  hash_n_string[lang].pop(m_h)
+                  just_string[lang].remove(last)
+            else:
+               for j, info in enumerate(option_info):
+                  gr1 = info.group(1)
+                  if is_viable_non_dupe(gr1, just_string[lang]):
+                     just_string[lang].add(gr1)
+                     m_h = create_non_dupe(re.sub(r'__+', '_', f'{opt_name}_INFO_{j}'), opt,
+                                           hash_n_string[lang])
+                     hash_n_string[lang][m_h] = gr1
+         else:
+            raise ValueError(f'Too few arguments in struct {struct_type_name[1]} option {option.group(1)}!')
+
+         # group 4:
+         if option.group(4):
+            for j, kv_set in enumerate(cor.p_key_value.finditer(option.group(4))):
+               set_key, set_value = kv_set.group(1, 2)
+               if not is_viable_value(set_value):
+                  if not is_viable_value(set_key):
+                     continue
+                  set_value = set_key
+               # re.fullmatch(r'(?:[+-][0-9]+)+', value[1:-1])
+               if set_value not in just_string[lang] and not re.sub(r'[+-]', '', set_value[1:-1]).isdigit():
+                  clean_key = set_key[1:-1]
+                  clean_key = remove_special_chars(clean_key).upper().replace(' ', '_')
+                  m_h = create_non_dupe(re.sub(r'__+', '_', f"OPTION_VAL_{clean_key}"), opt, hash_n_string[lang])
+                  hash_n_string[lang][m_h] = set_value
+                  just_string[lang].add(set_value)
+   return hash_n_string
+
+
+def create_msg_hash(intl_dir_path: str, core_name: str, keyword_string_dict: dict) -> dict:
+   """Creates '<core_name>.h' files in 'intl/_<lang>/' containing the macro name & string combinations.
+
+   :param intl_dir_path: Path to the intl directory.
+   :param core_name: Name of the core, used for the files' paths.
+   :param keyword_string_dict: Dictionary of the form { '_<lang>': { 'macro': 'string', ... }, ... }.
+   :return: Dictionary of the form { '_<lang>': 'path/to/file (./intl/_<lang>/<core_name>.h)', ... }.
+   """
+   files = {}
+   for localisation in keyword_string_dict:
+      path = os.path.join(intl_dir_path, core_name)  # intl/<core_name>/
+      files[localisation] = os.path.join(path, localisation + '.h')  # intl/<core_name>/_<lang>.h
+      if not os.path.exists(path):
+         os.makedirs(path)
+      with open(files[localisation], 'w', encoding='utf-8') as crowdin_file:
+         out_text = ''
+         for keyword in keyword_string_dict[localisation]:
+            out_text = f'{out_text}{keyword} {keyword_string_dict[localisation][keyword]}\n'
+         crowdin_file.write(out_text)
+   return files
+
+
+def h2json(file_paths: dict) -> dict:
+   """Converts .h files pointed to by file_paths into .jsons.
+
+   :param file_paths: Dictionary of the form { '_<lang>': 'path/to/file (./intl/_<lang>/<core_name>.h)', ... }.
+   :return: Dictionary of the form { '_<lang>': 'path/to/file (./intl/_<lang>/<core_name>.json)', ... }.
+   """
+   jsons = {}
+   for file_lang in file_paths:
+      if not os.path.isfile(file_paths[file_lang]):
+         continue
+
+      jsons[file_lang] = file_paths[file_lang][:-2] + '.json'
+
+      p = cor.p_masked
+
+      with open(file_paths[file_lang], 'r+', encoding='utf-8') as h_file:
+         text = h_file.read()
+         result = p.finditer(text)
+         messages = {}
+         for msg in result:
+            key, val = msg.group(1, 2)
+            if key not in messages:
+               if key and val:
+                  # unescape & remove "\n"
+                  messages[key] = re.sub(r'"\s*(?:(?:/\*(?:.|[\r\n])*?\*/|//.*[\r\n]+)\s*)*"',
+                                         '\\\n', val[1:-1].replace('\\\"', '"'))
+            else:
+               print(f"DUPLICATE KEY in {file_paths[file_lang]}: {key}")
+         with open(jsons[file_lang], 'w', encoding='utf-8') as json_file:
+            json.dump(messages, json_file, indent=2)
+
+   return jsons
+
+
+def json2h(intl_dir_path: str, file_list) -> None:
+   """Converts .json file in json_file_path into an .h ready to be included in C code.
+
+   :param intl_dir_path: Path to the intl/<core_name> directory.
+   :param file_list: Iterator of os.DirEntry objects. Contains localisation files to convert.
+   :return: None
+   """
+
+   p = cor.p_masked
+
+   def update(s_messages, s_template, s_source_messages, file_name):
+      translation = ''
+      template_messages = p.finditer(s_template)
+      for tp_msg in template_messages:
+         old_key = tp_msg.group(1)
+         if old_key in s_messages and s_messages[old_key] != s_source_messages[old_key]:
+            tl_msg_val = s_messages[old_key]
+            tl_msg_val = tl_msg_val.replace('"', '\\\"').replace('\n', '')  # escape
+            translation = ''.join((translation, '#define ', old_key, file_name.upper(), f' "{tl_msg_val}"\n'))
+
+         else:  # Remove English duplicates and non-translatable strings
+            translation = ''.join((translation, '#define ', old_key, file_name.upper(), ' NULL\n'))
+      return translation
+
+   us_h = os.path.join(intl_dir_path, '_us.h')
+   us_json = os.path.join(intl_dir_path, '_us.json')
+
+   with open(us_h, 'r', encoding='utf-8') as template_file:
+      template = template_file.read()
+   with open(us_json, 'r+', encoding='utf-8') as source_json_file:
+      source_messages = json.load(source_json_file)
+
+   for file in file_list:
+      if file.name.lower().startswith('_us') \
+         or file.name.lower().endswith('.h') \
+         or file.is_dir():
+         continue
+
+      with open(file.path, 'r+', encoding='utf-8') as json_file:
+         messages = json.load(json_file)
+         new_translation = update(messages, template, source_messages, os.path.splitext(file.name)[0])
+      with open(os.path.splitext(file.path)[0] + '.h', 'w', encoding='utf-8') as h_file:
+         h_file.seek(0)
+         h_file.write(new_translation)
+         h_file.truncate()
+   return
+
+
+def get_crowdin_client(dir_path: str) -> str:
+   """Makes sure the Crowdin CLI client is present. If it isn't, it is fetched & extracted.
+
+   :return: The path to 'crowdin-cli.jar'.
+   """
+   jar_name = 'crowdin-cli.jar'
+   jar_path = os.path.join(dir_path, jar_name)
+
+   if not os.path.isfile(jar_path):
+      print('Downloading crowdin-cli.jar')
+      crowdin_cli_file = os.path.join(dir_path, 'crowdin-cli.zip')
+      crowdin_cli_url = 'https://downloads.crowdin.com/cli/v3/crowdin-cli.zip'
+      req.urlretrieve(crowdin_cli_url, crowdin_cli_file)
+      import zipfile
+      with zipfile.ZipFile(crowdin_cli_file, 'r') as zip_ref:
+         jar_dir = zip_ref.namelist()[0]
+         for file in zip_ref.namelist():
+            if file.endswith(jar_name):
+               jar_file = file
+               break
+         zip_ref.extract(jar_file)
+         os.rename(jar_file, jar_path)
+         os.remove(crowdin_cli_file)
+         shutil.rmtree(jar_dir)
+   return jar_path
+
+
+def create_intl_file(localisation_file_path: str, intl_dir_path: str, text: str, file_path: str) -> None:
+   """Creates 'libretro_core_options_intl.h' from Crowdin translations.
+
+   :param localisation_file_path: Path to 'libretro_core_options_intl.h'
+   :param intl_dir_path: Path to the intl/<core_name> directory.
+   :param text: Content of the 'libretro_core_options.h' being translated.
+   :param file_path: Path to the '_us.h' file, containing the original English texts.
+   :return: None
+   """
+   msg_dict = {}
+   lang_up = ''
+
+   def replace_pair(pair_match):
+      """Replaces a key-value-pair of an option with the macros corresponding to the language.
+
+      :param pair_match: The re match object representing the key-value-pair block.
+      :return: Replacement string.
+      """
+      offset = pair_match.start(0)
+      if pair_match.group(1):  # key
+         if pair_match.group(2) in msg_dict:  # value
+            val = msg_dict[pair_match.group(2)] + lang_up
+         elif pair_match.group(1) in msg_dict:  # use key if value not viable (e.g. NULL)
+            val = msg_dict[pair_match.group(1)] + lang_up
+         else:
+            return pair_match.group(0)
+      else:
+         return pair_match.group(0)
+      res = pair_match.group(0)[:pair_match.start(2) - offset] + val \
+            + pair_match.group(0)[pair_match.end(2) - offset:]
+      return res
+
+   def replace_info(info_match):
+      """Replaces the 'additional strings' of an option with the macros corresponding to the language.
+
+      :param info_match: The re match object representing the 'additional strings' block.
+      :return: Replacement string.
+      """
+      offset = info_match.start(0)
+      if info_match.group(1) in msg_dict:
+         res = info_match.group(0)[:info_match.start(1) - offset] + \
+               msg_dict[info_match.group(1)] + lang_up + \
+               info_match.group(0)[info_match.end(1) - offset:]
+         return res
+      else:
+         return info_match.group(0)
+
+   def replace_option(option_match):
+      """Replaces strings within an option
+      '{ "opt_key", "label", "additional strings", ..., { {"key", "value"}, ... }, ... }'
+      within a struct with the macros corresponding to the language:
+      '{ "opt_key", MACRO_LABEL, MACRO_STRINGS, ..., { {"key", MACRO_VALUE}, ... }, ... }'
+
+      :param option_match: The re match object representing the option.
+      :return: Replacement string.
+      """
+      # label
+      offset = option_match.start(0)
+      if option_match.group(2):
+         res = option_match.group(0)[:option_match.start(2) - offset] + msg_dict[option_match.group(2)] + lang_up
+      else:
+         return option_match.group(0)
+      # additional block
+      if option_match.group(3):
+         res = res + option_match.group(0)[option_match.end(2) - offset:option_match.start(3) - offset]
+         new_info = p.sub(replace_info, option_match.group(3))
+         res = res + new_info
+      else:
+         return res + option_match.group(0)[option_match.end(2) - offset:]
+      # key-value-pairs
+      if option_match.group(4):
+         res = res + option_match.group(0)[option_match.end(3) - offset:option_match.start(4) - offset]
+         new_pairs = cor.p_key_value.sub(replace_pair, option_match.group(4))
+         res = res + new_pairs + option_match.group(0)[option_match.end(4) - offset:]
+      else:
+         res = res + option_match.group(0)[option_match.end(3) - offset:]
+
+      return res
+
+   # ------------------------------------------------------------------------------------
+
+   with open(file_path, 'r+', encoding='utf-8') as template:  # intl/<core_name>/_us.h
+      masked_msgs = cor.p_masked.finditer(template.read())
+
+   for msg in masked_msgs:
+      msg_dict[msg.group(2)] = msg.group(1)
+
+   # top of the file - in case there is no file to copy it from
+   out_txt = "﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__\n" \
+             "#define LIBRETRO_CORE_OPTIONS_INTL_H__\n\n" \
+             "#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)\n" \
+             "/* https://support.microsoft.com/en-us/kb/980263 */\n" \
+             '#pragma execution_character_set("utf-8")\n' \
+             "#pragma warning(disable:4566)\n" \
+             "#endif\n\n" \
+             "#include <libretro.h>\n\n" \
+             '#ifdef __cplusplus\n' \
+             'extern "C" {\n' \
+             '#endif\n'
+
+   if os.path.isfile(localisation_file_path):
+      # copy top of the file for re-use
+      with open(localisation_file_path, 'r', encoding='utf-8') as intl:  # libretro_core_options_intl.h
+         in_text = intl.read()
+         intl_start = re.search(re.escape('/*\n'
+                                          ' ********************************\n'
+                                          ' * Core Option Definitions\n'
+                                          ' ********************************\n'
+                                          '*/\n'), in_text)
+         if intl_start:
+            out_txt = in_text[:intl_start.end(0)]
+         else:
+            intl_start = re.search(re.escape('#ifdef __cplusplus\n'
+                                             'extern "C" {\n'
+                                             '#endif\n'), in_text)
+            if intl_start:
+               out_txt = in_text[:intl_start.end(0)]
+
+   # only write to file, if there is anything worthwhile to write!
+   overwrite = False
+
+   # iterate through localisation files
+   files = {}
+   for file in os.scandir(intl_dir_path):
+      files[file.name] = {'is_file': file.is_file(), 'path': file.path}
+   for file in sorted(files):  # intl/<core_name>/_*
+      if files[file]['is_file'] \
+         and file.startswith('_') \
+         and file.endswith('.h') \
+         and not file.startswith('_us'):
+         translation_path = files[file]['path']  # <core_name>_<lang>.h
+         # all structs: group(0) full struct, group(1) beginning, group(2) content
+         struct_groups = cor.p_struct.finditer(text)
+         lang_low = os.path.splitext(file)[0].lower()
+         lang_up = lang_low.upper()
+         out_txt = out_txt + f'/* RETRO_LANGUAGE{lang_up} */\n\n'  # /* RETRO_LANGUAGE_NM */
+
+         # copy adjusted translations (makros)
+         with open(translation_path, 'r+', encoding='utf-8') as f_in:  # <core name>.h
+            out_txt = out_txt + f_in.read() + '\n'
+         # replace English texts with makros
+         for construct in struct_groups:
+            declaration = construct.group(1)
+            struct_type_name = get_struct_type_name(declaration)
+            if 3 > len(struct_type_name):  # no language specifier
+               new_decl = re.sub(re.escape(struct_type_name[1]), struct_type_name[1] + lang_low, declaration)
+            else:
+               new_decl = re.sub(re.escape(struct_type_name[2]), lang_low, declaration)
+               if '_us' != struct_type_name[2]:
+                  continue
+
+            p = cor.p_info
+            if 'retro_core_option_v2_category' == struct_type_name[0]:
+               p = cor.p_info_cat
+            offset_construct = construct.start(0)
+            start = construct.end(1) - offset_construct
+            end = construct.start(2) - offset_construct
+            out_txt = out_txt + new_decl + construct.group(0)[start:end]
+
+            content = construct.group(2)
+            new_content = cor.p_option.sub(replace_option, content)
+
+            start = construct.end(2) - offset_construct
+            out_txt = out_txt + new_content + construct.group(0)[start:] + '\n'
+
+            # for v2
+            if 'retro_core_option_v2_definition' == struct_type_name[0]:
+               out_txt = out_txt + f'struct retro_core_options_v2 options{lang_low}' \
+                                   ' = {\n' \
+                                   f'   option_cats{lang_low},\n' \
+                                   f'   option_defs{lang_low}\n' \
+                                   '};\n\n'
+         # if it got this far, we've got something to write
+         overwrite = True
+
+   # only write to file, if there is anything worthwhile to write!
+   if overwrite:
+      with open(localisation_file_path, 'w', encoding='utf-8') as intl:
+         intl.write(out_txt + '\n#ifdef __cplusplus\n'
+                              '}\n#endif\n'
+                              '\n#endif')
+   return
+
+
+# --------------------          MAIN          -------------------- #
+
+if __name__ == '__main__':
+   try:
+      if os.path.isfile(sys.argv[1]):
+         _temp = os.path.dirname(sys.argv[1])
+      else:
+         _temp = sys.argv[1]
+      while _temp.endswith('/') or _temp.endswith('\\'):
+         _temp = _temp[:-1]
+      TARGET_DIR_PATH = _temp
+   except IndexError:
+      TARGET_DIR_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+      print("No path provided, assuming parent directory:\n" + TARGET_DIR_PATH)
+
+   CORE_NAME = clean_file_name(sys.argv[2])
+
+   DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+   H_FILE_PATH = os.path.join(TARGET_DIR_PATH, 'libretro_core_options.h')
+   INTL_FILE_PATH = os.path.join(TARGET_DIR_PATH, 'libretro_core_options_intl.h')
+
+   print('Getting texts from libretro_core_options.h')
+   with open(H_FILE_PATH, 'r+', encoding='utf-8') as _h_file:
+      _main_text = _h_file.read()
+   _hash_n_str = get_texts(_main_text)
+   _files = create_msg_hash(DIR_PATH, CORE_NAME, _hash_n_str)
+   _source_jsons = h2json(_files)
+
+   print('Getting texts from libretro_core_options_intl.h')
+   if os.path.isfile(INTL_FILE_PATH):
+      with open(INTL_FILE_PATH, 'r+', encoding='utf-8') as _intl_file:
+         _intl_text = _intl_file.read()
+         _hash_n_str_intl = get_texts(_intl_text)
+         _intl_files = create_msg_hash(DIR_PATH, CORE_NAME, _hash_n_str_intl)
+         _intl_jsons = h2json(_intl_files)
+
+   print('\nAll done!')

--- a/intl/crowdin.yaml
+++ b/intl/crowdin.yaml
@@ -1,0 +1,13 @@
+"project_id": "380544"
+"api_token": "_secret_"
+"base_url": "https://api.crowdin.com"
+"preserve_hierarchy": true
+
+"files":
+  [
+    {
+      "source": "/intl/_core_name_/_us.json",
+      "dest": "/_core_name_/_core_name_.json",
+      "translation": "/intl/_core_name_/_%two_letters_code%.json",
+    },
+  ]

--- a/intl/crowdin_prep.py
+++ b/intl/crowdin_prep.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import core_option_translation as t
+
+if __name__ == '__main__':
+   try:
+      if t.os.path.isfile(t.sys.argv[1]):
+         _temp = t.os.path.dirname(t.sys.argv[1])
+      else:
+         _temp = t.sys.argv[1]
+      while _temp.endswith('/') or _temp.endswith('\\'):
+         _temp = _temp[:-1]
+      TARGET_DIR_PATH = _temp
+   except IndexError:
+      TARGET_DIR_PATH = t.os.path.dirname(t.os.path.dirname(t.os.path.realpath(__file__)))
+      print("No path provided, assuming parent directory:\n" + TARGET_DIR_PATH)
+
+   CORE_NAME = t.clean_file_name(t.sys.argv[2])
+   DIR_PATH = t.os.path.dirname(t.os.path.realpath(__file__))
+   H_FILE_PATH = t.os.path.join(TARGET_DIR_PATH, 'libretro_core_options.h')
+
+   print('Getting texts from libretro_core_options.h')
+   with open(H_FILE_PATH, 'r+', encoding='utf-8') as _h_file:
+      _main_text = _h_file.read()
+   _hash_n_str = t.get_texts(_main_text)
+   _files = t.create_msg_hash(DIR_PATH, CORE_NAME, _hash_n_str)
+
+   _source_jsons = t.h2json(_files)
+
+   print('\nAll done!')

--- a/intl/crowdin_source_upload.py
+++ b/intl/crowdin_source_upload.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import re
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+import zipfile
+import core_option_translation as t
+
+# --------------------          MAIN          -------------------- #
+
+if __name__ == '__main__':
+   # Check Crowdin API Token and core name
+   try:
+      API_KEY = sys.argv[1]
+      CORE_NAME = t.clean_file_name(sys.argv[2])
+   except IndexError as e:
+      print('Please provide Crowdin API Token and core name!')
+      raise e
+
+   DIR_PATH = t.os.path.dirname(t.os.path.realpath(__file__))
+   YAML_PATH = t.os.path.join(DIR_PATH, 'crowdin.yaml')
+
+   # Apply Crowdin API Key
+   with open(YAML_PATH, 'r') as crowdin_config_file:
+      crowdin_config = crowdin_config_file.read()
+   crowdin_config = re.sub(r'"api_token": "_secret_"',
+                           f'"api_token": "{API_KEY}"',
+                           crowdin_config, 1)
+   crowdin_config = re.sub(r'/_core_name_',
+                           f'/{CORE_NAME}'
+                           , crowdin_config)
+   with open(YAML_PATH, 'w') as crowdin_config_file:
+      crowdin_config_file.write(crowdin_config)
+
+   try:
+      # Download Crowdin CLI
+      jar_name = 'crowdin-cli.jar'
+      jar_path = t.os.path.join(DIR_PATH, jar_name)
+      crowdin_cli_file = 'crowdin-cli.zip'
+      crowdin_cli_url = 'https://downloads.crowdin.com/cli/v3/' + crowdin_cli_file
+      crowdin_cli_path = t.os.path.join(DIR_PATH, crowdin_cli_file)
+
+      if not os.path.isfile(t.os.path.join(DIR_PATH, jar_name)):
+         print('download crowdin-cli.jar')
+         urllib.request.urlretrieve(crowdin_cli_url, crowdin_cli_path)
+         with zipfile.ZipFile(crowdin_cli_path, 'r') as zip_ref:
+            jar_dir = t.os.path.join(DIR_PATH, zip_ref.namelist()[0])
+            for file in zip_ref.namelist():
+               if file.endswith(jar_name):
+                  jar_file = file
+                  break
+            zip_ref.extract(jar_file, path=DIR_PATH)
+            os.rename(t.os.path.join(DIR_PATH, jar_file), jar_path)
+            os.remove(crowdin_cli_path)
+            shutil.rmtree(jar_dir)
+
+      print('upload source *.json')
+      subprocess.run(['java', '-jar', jar_path, 'upload', 'sources', '--config', YAML_PATH])
+
+      # Reset Crowdin API Key
+      with open(YAML_PATH, 'r') as crowdin_config_file:
+         crowdin_config = crowdin_config_file.read()
+      crowdin_config = re.sub(r'"api_token": ".*?"',
+                              '"api_token": "_secret_"',
+                              crowdin_config, 1)
+
+      # TODO this is NOT safe!
+      crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
+                              '/_core_name_',
+                              crowdin_config)
+
+      with open(YAML_PATH, 'w') as crowdin_config_file:
+         crowdin_config_file.write(crowdin_config)
+
+   except Exception as e:
+      # Try really hard to reset Crowdin API Key
+      with open(YAML_PATH, 'r') as crowdin_config_file:
+         crowdin_config = crowdin_config_file.read()
+      crowdin_config = re.sub(r'"api_token": ".*?"',
+                              '"api_token": "_secret_"',
+                              crowdin_config, 1)
+
+      # TODO this is NOT safe!
+      crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
+                              '/_core_name_',
+                              crowdin_config)
+
+      with open(YAML_PATH, 'w') as crowdin_config_file:
+         crowdin_config_file.write(crowdin_config)
+      raise e

--- a/intl/crowdin_translate.py
+++ b/intl/crowdin_translate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import core_option_translation as t
+
+if __name__ == '__main__':
+   try:
+      if t.os.path.isfile(t.sys.argv[1]):
+         _temp = t.os.path.dirname(t.sys.argv[1])
+      else:
+         _temp = t.sys.argv[1]
+      while _temp.endswith('/') or _temp.endswith('\\'):
+         _temp = _temp[:-1]
+      TARGET_DIR_PATH = _temp
+   except IndexError:
+      TARGET_DIR_PATH = t.os.path.dirname(t.os.path.dirname(t.os.path.realpath(__file__)))
+      print("No path provided, assuming parent directory:\n" + TARGET_DIR_PATH)
+
+   CORE_NAME = t.clean_file_name(t.sys.argv[2])
+   DIR_PATH = t.os.path.dirname(t.os.path.realpath(__file__))
+   LOCALISATIONS_PATH = t.os.path.join(DIR_PATH, CORE_NAME)
+   US_FILE_PATH = t.os.path.join(LOCALISATIONS_PATH, '_us.h')
+   H_FILE_PATH = t.os.path.join(TARGET_DIR_PATH, 'libretro_core_options.h')
+   INTL_FILE_PATH = t.os.path.join(TARGET_DIR_PATH, 'libretro_core_options_intl.h')
+
+   print('Getting texts from libretro_core_options.h')
+   with open(H_FILE_PATH, 'r+', encoding='utf-8') as _h_file:
+      _main_text = _h_file.read()
+   _hash_n_str = t.get_texts(_main_text)
+   _files = t.create_msg_hash(DIR_PATH, CORE_NAME, _hash_n_str)
+   _source_jsons = t.h2json(_files)
+
+   print('Converting translations *.json to *.h:')
+   localisation_files = t.os.scandir(LOCALISATIONS_PATH)
+   t.json2h(LOCALISATIONS_PATH, localisation_files)
+
+   print('Constructing libretro_core_options_intl.h')
+   t.create_intl_file(INTL_FILE_PATH, LOCALISATIONS_PATH, _main_text, _files["_us"])
+
+   print('\nAll done!')

--- a/intl/crowdin_translation_download.py
+++ b/intl/crowdin_translation_download.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import re
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+import zipfile
+import core_option_translation as t
+
+# --------------------          MAIN          -------------------- #
+
+if __name__ == '__main__':
+   # Check Crowdin API Token and core name
+   try:
+      API_KEY = sys.argv[1]
+      CORE_NAME = t.clean_file_name(sys.argv[2])
+   except IndexError as e:
+      print('Please provide Crowdin API Token and core name!')
+      raise e
+
+   DIR_PATH = t.os.path.dirname(t.os.path.realpath(__file__))
+   YAML_PATH = t.os.path.join(DIR_PATH, 'crowdin.yaml')
+
+   # Apply Crowdin API Key
+   with open(YAML_PATH, 'r') as crowdin_config_file:
+      crowdin_config = crowdin_config_file.read()
+   crowdin_config = re.sub(r'"api_token": "_secret_"',
+                           f'"api_token": "{API_KEY}"',
+                           crowdin_config, 1)
+   crowdin_config = re.sub(r'/_core_name_',
+                           f'/{CORE_NAME}'
+                           , crowdin_config)
+   with open(YAML_PATH, 'w') as crowdin_config_file:
+      crowdin_config_file.write(crowdin_config)
+
+   try:
+      # Download Crowdin CLI
+      jar_name = 'crowdin-cli.jar'
+      jar_path = t.os.path.join(DIR_PATH, jar_name)
+      crowdin_cli_file = 'crowdin-cli.zip'
+      crowdin_cli_url = 'https://downloads.crowdin.com/cli/v3/' + crowdin_cli_file
+      crowdin_cli_path = t.os.path.join(DIR_PATH, crowdin_cli_file)
+
+      if not os.path.isfile(t.os.path.join(DIR_PATH, jar_name)):
+         print('download crowdin-cli.jar')
+         urllib.request.urlretrieve(crowdin_cli_url, crowdin_cli_path)
+         with zipfile.ZipFile(crowdin_cli_path, 'r') as zip_ref:
+            jar_dir = t.os.path.join(DIR_PATH, zip_ref.namelist()[0])
+            for file in zip_ref.namelist():
+               if file.endswith(jar_name):
+                  jar_file = file
+                  break
+            zip_ref.extract(jar_file, path=DIR_PATH)
+            os.rename(t.os.path.join(DIR_PATH, jar_file), jar_path)
+            os.remove(crowdin_cli_path)
+            shutil.rmtree(jar_dir)
+
+      print('download translation *.json')
+      subprocess.run(['java', '-jar', jar_path, 'download', '--config', YAML_PATH])
+
+      # Reset Crowdin API Key
+      with open(YAML_PATH, 'r') as crowdin_config_file:
+         crowdin_config = crowdin_config_file.read()
+      crowdin_config = re.sub(r'"api_token": ".*?"',
+                              '"api_token": "_secret_"',
+                              crowdin_config, 1)
+
+      # TODO this is NOT safe!
+      crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
+                              '/_core_name_',
+                              crowdin_config)
+
+      with open(YAML_PATH, 'w') as crowdin_config_file:
+         crowdin_config_file.write(crowdin_config)
+
+   except Exception as e:
+      # Try really hard to reset Crowdin API Key
+      with open(YAML_PATH, 'r') as crowdin_config_file:
+         crowdin_config = crowdin_config_file.read()
+      crowdin_config = re.sub(r'"api_token": ".*?"',
+                              '"api_token": "_secret_"',
+                              crowdin_config, 1)
+
+      # TODO this is NOT safe!
+      crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
+                              '/_core_name_',
+                              crowdin_config)
+
+      with open(YAML_PATH, 'w') as crowdin_config_file:
+         crowdin_config_file.write(crowdin_config)
+      raise e

--- a/intl/download_workflow.py
+++ b/intl/download_workflow.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+try:
+   api_key = sys.argv[1]
+   core_name = sys.argv[2]
+   dir_path = sys.argv[3]
+except IndexError as e:
+   print('Please provide path to libretro_core_options.h, Crowdin API Token and core name!')
+   raise e
+
+subprocess.run(['python3', 'intl/crowdin_prep.py', dir_path, core_name])
+subprocess.run(['python3', 'intl/crowdin_translation_download.py', api_key, core_name])
+subprocess.run(['python3', 'intl/crowdin_translate.py', dir_path, core_name])

--- a/intl/initial_sync.py
+++ b/intl/initial_sync.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import re
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+import zipfile
+import core_option_translation as t
+
+# --------------------          MAIN          -------------------- #
+
+if __name__ == '__main__':
+   # Check Crowdin API Token and core name
+   try:
+      API_KEY = sys.argv[1]
+      CORE_NAME = t.clean_file_name(sys.argv[2])
+   except IndexError as e:
+      print('Please provide Crowdin API Token and core name!')
+      raise e
+
+   DIR_PATH = t.os.path.dirname(t.os.path.realpath(__file__))
+   YAML_PATH = t.os.path.join(DIR_PATH, 'crowdin.yaml')
+
+   # Apply Crowdin API Key
+   with open(YAML_PATH, 'r') as crowdin_config_file:
+      crowdin_config = crowdin_config_file.read()
+   crowdin_config = re.sub(r'"api_token": "_secret_"',
+                           f'"api_token": "{API_KEY}"',
+                           crowdin_config, 1)
+   crowdin_config = re.sub(r'/_core_name_',
+                           f'/{CORE_NAME}'
+                           , crowdin_config)
+   with open(YAML_PATH, 'w') as crowdin_config_file:
+      crowdin_config_file.write(crowdin_config)
+
+   try:
+      # Download Crowdin CLI
+      jar_name = 'crowdin-cli.jar'
+      jar_path = t.os.path.join(DIR_PATH, jar_name)
+      crowdin_cli_file = 'crowdin-cli.zip'
+      crowdin_cli_url = 'https://downloads.crowdin.com/cli/v3/' + crowdin_cli_file
+      crowdin_cli_path = t.os.path.join(DIR_PATH, crowdin_cli_file)
+
+      if not os.path.isfile(t.os.path.join(DIR_PATH, jar_name)):
+         print('download crowdin-cli.jar')
+         urllib.request.urlretrieve(crowdin_cli_url, crowdin_cli_path)
+         with zipfile.ZipFile(crowdin_cli_path, 'r') as zip_ref:
+            jar_dir = t.os.path.join(DIR_PATH, zip_ref.namelist()[0])
+            for file in zip_ref.namelist():
+               if file.endswith(jar_name):
+                  jar_file = file
+                  break
+            zip_ref.extract(jar_file, path=DIR_PATH)
+            os.rename(t.os.path.join(DIR_PATH, jar_file), jar_path)
+            os.remove(crowdin_cli_path)
+            shutil.rmtree(jar_dir)
+
+      print('upload source & translations *.json')
+      subprocess.run(['java', '-jar', jar_path, 'upload', 'sources', '--config', YAML_PATH])
+      subprocess.run(['java', '-jar', jar_path, 'upload', 'translations', '--config', YAML_PATH])
+
+      print('wait for crowdin server to process data')
+      time.sleep(10)
+
+      print('download translation *.json')
+      subprocess.run(['java', '-jar', jar_path, 'download', '--config', YAML_PATH])
+
+      # Reset Crowdin API Key
+      with open(YAML_PATH, 'r') as crowdin_config_file:
+         crowdin_config = crowdin_config_file.read()
+      crowdin_config = re.sub(r'"api_token": ".*?"', '"api_token": "_secret_"', crowdin_config, 1)
+
+      # TODO this is NOT safe!
+      crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
+                              '/_core_name_',
+                              crowdin_config)
+
+      with open(YAML_PATH, 'w') as crowdin_config_file:
+         crowdin_config_file.write(crowdin_config)
+
+      with open('intl/download_workflow.py', 'r') as workflow:
+         workflow_config = workflow.read()
+      workflow_config = workflow_config.replace(
+         "subprocess.run(['python3', 'intl/core_option_translation.py', dir_path, core_name])",
+         "subprocess.run(['python3', 'intl/crowdin_prep.py', dir_path, core_name])"
+      )
+      workflow_config = workflow_config.replace(
+         "subprocess.run(['python3', 'intl/initial_sync.py', api_key, core_name])",
+         "subprocess.run(['python3', 'intl/crowdin_translation_download.py', api_key, core_name])"
+      )
+      with open('intl/download_workflow.py', 'w') as workflow:
+         workflow.write(workflow_config)
+
+   except Exception as e:
+      # Try really hard to reset Crowdin API Key
+      with open(YAML_PATH, 'r') as crowdin_config_file:
+         crowdin_config = crowdin_config_file.read()
+      crowdin_config = re.sub(r'"api_token": ".*?"',
+                              '"api_token": "_secret_"',
+                              crowdin_config, 1)
+
+      # TODO this is NOT safe!
+      crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
+                              '/_core_name_',
+                              crowdin_config)
+
+      with open(YAML_PATH, 'w') as crowdin_config_file:
+         crowdin_config_file.write(crowdin_config)
+      raise e

--- a/intl/upload_workflow.py
+++ b/intl/upload_workflow.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+try:
+   api_key = sys.argv[1]
+   core_name = sys.argv[2]
+   dir_path = sys.argv[3]
+except IndexError as e:
+   print('Please provide path to libretro_core_options.h, Crowdin API Token and core name!')
+   raise e
+
+subprocess.run(['python3', 'intl/crowdin_prep.py', dir_path, core_name])
+subprocess.run(['python3', 'intl/crowdin_source_upload.py', api_key, core_name])

--- a/intl/v1_to_v2_converter.py
+++ b/intl/v1_to_v2_converter.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+
+"""Core options v1 to v2 converter
+
+Just run this script as follows, to convert 'libretro_core_options.h' & 'Libretro_coreoptions_intl.h' to v2:
+python3 "/path/to/v1_to_v2_converter.py" "/path/to/where/libretro_core_options.h & Libretro_coreoptions_intl.h/are"
+
+The original files will be preserved as *.v1
+"""
+import core_option_regex as cor
+import os
+import sys
+
+
+def create_v2_code_file(struct_text, file_name):
+   def replace_option(option_match):
+      _offset = option_match.start(0)
+
+      if option_match.group(3):
+         res = option_match.group(0)[:option_match.end(2) - _offset] + ',\n      NULL' + \
+               option_match.group(0)[option_match.end(2) - _offset:option_match.end(3) - _offset] + \
+               'NULL,\n      NULL,\n      ' + option_match.group(0)[option_match.end(3) - _offset:]
+      else:
+         return option_match.group(0)
+
+      return res
+
+   comment_v1 = '/*\n' \
+                ' ********************************\n' \
+                ' * VERSION: 1.3\n' \
+                ' ********************************\n' \
+                ' *\n' \
+                ' * - 1.3: Move translations to libretro_core_options_intl.h\n' \
+                ' *        - libretro_core_options_intl.h includes BOM and utf-8\n' \
+                ' *          fix for MSVC 2010-2013\n' \
+                ' *        - Added HAVE_NO_LANGEXTRA flag to disable translations\n' \
+                ' *          on platforms/compilers without BOM support\n' \
+                ' * - 1.2: Use core options v1 interface when\n' \
+                ' *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1\n' \
+                ' *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)\n' \
+                ' * - 1.1: Support generation of core options v0 retro_core_option_value\n' \
+                ' *        arrays containing options with a single value\n' \
+                ' * - 1.0: First commit\n' \
+                '*/\n'
+
+   comment_v2 = '/*\n' \
+                ' ********************************\n' \
+                ' * VERSION: 2.0\n' \
+                ' ********************************\n' \
+                ' *\n' \
+                ' * - 2.0: Add support for core options v2 interface\n' \
+                ' * - 1.3: Move translations to libretro_core_options_intl.h\n' \
+                ' *        - libretro_core_options_intl.h includes BOM and utf-8\n' \
+                ' *          fix for MSVC 2010-2013\n' \
+                ' *        - Added HAVE_NO_LANGEXTRA flag to disable translations\n' \
+                ' *          on platforms/compilers without BOM support\n' \
+                ' * - 1.2: Use core options v1 interface when\n' \
+                ' *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1\n' \
+                ' *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)\n' \
+                ' * - 1.1: Support generation of core options v0 retro_core_option_value\n' \
+                ' *        arrays containing options with a single value\n' \
+                ' * - 1.0: First commit\n' \
+                '*/\n'
+
+   p_intl = cor.p_intl
+   p_set = cor.p_set
+   new_set = 'static INLINE void libretro_set_core_options(retro_environment_t environ_cb,\n' \
+             '      bool *categories_supported)\n' \
+             '{\n' \
+             '   unsigned version  = 0;\n' \
+             '#ifndef HAVE_NO_LANGEXTRA\n' \
+             '   unsigned language = 0;\n' \
+             '#endif\n' \
+             '\n' \
+             '   if (!environ_cb || !categories_supported)\n' \
+             '      return;\n' \
+             '\n' \
+             '   *categories_supported = false;\n' \
+             '\n' \
+             '   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))\n' \
+             '      version = 0;\n' \
+             '\n' \
+             '   if (version >= 2)\n' \
+             '   {\n' \
+             '#ifndef HAVE_NO_LANGEXTRA\n' \
+             '      struct retro_core_options_v2_intl core_options_intl;\n' \
+             '\n' \
+             '      core_options_intl.us    = &options_us;\n' \
+             '      core_options_intl.local = NULL;\n' \
+             '\n' \
+             '      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&\n' \
+             '          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))\n' \
+             '         core_options_intl.local = options_intl[language];\n' \
+             '\n' \
+             '      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,\n' \
+             '            &core_options_intl);\n' \
+             '#else\n' \
+             '      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,\n' \
+             '            &options_us);\n' \
+             '#endif\n' \
+             '   }\n' \
+             '   else\n' \
+             '   {\n' \
+             '      size_t i, j;\n' \
+             '      size_t option_index              = 0;\n' \
+             '      size_t num_options               = 0;\n' \
+             '      struct retro_core_option_definition\n' \
+             '            *option_v1_defs_us         = NULL;\n' \
+             '#ifndef HAVE_NO_LANGEXTRA\n' \
+             '      size_t num_options_intl          = 0;\n' \
+             '      struct retro_core_option_v2_definition\n' \
+             '            *option_defs_intl          = NULL;\n' \
+             '      struct retro_core_option_definition\n' \
+             '            *option_v1_defs_intl       = NULL;\n' \
+             '      struct retro_core_options_intl\n' \
+             '            core_options_v1_intl;\n' \
+             '#endif\n' \
+             '      struct retro_variable *variables = NULL;\n' \
+             '      char **values_buf                = NULL;\n' \
+             '\n' \
+             '      /* Determine total number of options */\n' \
+             '      while (true)\n' \
+             '      {\n' \
+             '         if (option_defs_us[num_options].key)\n' \
+             '            num_options++;\n' \
+             '         else\n' \
+             '            break;\n' \
+             '      }\n' \
+             '\n' \
+             '      if (version >= 1)\n' \
+             '      {\n' \
+             '         /* Allocate US array */\n' \
+             '         option_v1_defs_us = (struct retro_core_option_definition *)\n' \
+             '               calloc(num_options + 1, sizeof(struct retro_core_option_definition));\n' \
+             '\n' \
+             '         /* Copy parameters from option_defs_us array */\n' \
+             '         for (i = 0; i < num_options; i++)\n' \
+             '         {\n' \
+             '            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];\n' \
+             '            struct retro_core_option_value *option_values         = option_def_us->values;\n' \
+             '            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];\n' \
+             '            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;\n' \
+             '\n' \
+             '            option_v1_def_us->key           = option_def_us->key;\n' \
+             '            option_v1_def_us->desc          = option_def_us->desc;\n' \
+             '            option_v1_def_us->info          = option_def_us->info;\n' \
+             '            option_v1_def_us->default_value = option_def_us->default_value;\n' \
+             '\n' \
+             '            /* Values must be copied individually... */\n' \
+             '            while (option_values->value)\n' \
+             '            {\n' \
+             '               option_v1_values->value = option_values->value;\n' \
+             '               option_v1_values->label = option_values->label;\n' \
+             '\n' \
+             '               option_values++;\n' \
+             '               option_v1_values++;\n' \
+             '            }\n' \
+             '         }\n' \
+             '\n' \
+             '#ifndef HAVE_NO_LANGEXTRA\n' \
+             '         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&\n' \
+             '             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&\n' \
+             '             options_intl[language])\n' \
+             '            option_defs_intl = options_intl[language]->definitions;\n' \
+             '\n' \
+             '         if (option_defs_intl)\n' \
+             '         {\n' \
+             '            /* Determine number of intl options */\n' \
+             '            while (true)\n' \
+             '            {\n' \
+             '               if (option_defs_intl[num_options_intl].key)\n' \
+             '                  num_options_intl++;\n' \
+             '               else\n' \
+             '                  break;\n' \
+             '            }\n' \
+             '\n' \
+             '            /* Allocate intl array */\n' \
+             '            option_v1_defs_intl = (struct retro_core_option_definition *)\n' \
+             '                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));\n' \
+             '\n' \
+             '            /* Copy parameters from option_defs_intl array */\n' \
+             '            for (i = 0; i < num_options_intl; i++)\n' \
+             '            {\n' \
+             '               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];\n' \
+             '               struct retro_core_option_value *option_values           = option_def_intl->values;\n' \
+             '               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];\n' \
+             '               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;\n' \
+             '\n' \
+             '               option_v1_def_intl->key           = option_def_intl->key;\n' \
+             '               option_v1_def_intl->desc          = option_def_intl->desc;\n' \
+             '               option_v1_def_intl->info          = option_def_intl->info;\n' \
+             '               option_v1_def_intl->default_value = option_def_intl->default_value;\n' \
+             '\n' \
+             '               /* Values must be copied individually... */\n' \
+             '               while (option_values->value)\n' \
+             '               {\n' \
+             '                  option_v1_values->value = option_values->value;\n' \
+             '                  option_v1_values->label = option_values->label;\n' \
+             '\n' \
+             '                  option_values++;\n' \
+             '                  option_v1_values++;\n' \
+             '               }\n' \
+             '            }\n' \
+             '         }\n' \
+             '\n' \
+             '         core_options_v1_intl.us    = option_v1_defs_us;\n' \
+             '         core_options_v1_intl.local = option_v1_defs_intl;\n' \
+             '\n' \
+             '         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);\n' \
+             '#else\n' \
+             '         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);\n' \
+             '#endif\n' \
+             '      }\n' \
+             '      else\n' \
+             '      {\n' \
+             '         /* Allocate arrays */\n' \
+             '         variables  = (struct retro_variable *)calloc(num_options + 1,\n' \
+             '               sizeof(struct retro_variable));\n' \
+             '         values_buf = (char **)calloc(num_options, sizeof(char *));\n' \
+             '\n' \
+             '         if (!variables || !values_buf)\n' \
+             '            goto error;\n' \
+             '\n' \
+             '         /* Copy parameters from option_defs_us array */\n' \
+             '         for (i = 0; i < num_options; i++)\n' \
+             '         {\n' \
+             '            const char *key                        = option_defs_us[i].key;\n' \
+             '            const char *desc                       = option_defs_us[i].desc;\n' \
+             '            const char *default_value              = option_defs_us[i].default_value;\n' \
+             '            struct retro_core_option_value *values = option_defs_us[i].values;\n' \
+             '            size_t buf_len                         = 3;\n' \
+             '            size_t default_index                   = 0;\n' \
+             '\n' \
+             '            values_buf[i] = NULL;\n' \
+             '\n' \
+             '            if (desc)\n' \
+             '            {\n' \
+             '               size_t num_values = 0;\n' \
+             '\n' \
+             '               /* Determine number of values */\n' \
+             '               while (true)\n' \
+             '               {\n' \
+             '                  if (values[num_values].value)\n' \
+             '                  {\n' \
+             '                     /* Check if this is the default value */\n' \
+             '                     if (default_value)\n' \
+             '                        if (strcmp(values[num_values].value, default_value) == 0)\n' \
+             '                           default_index = num_values;\n' \
+             '\n' \
+             '                     buf_len += strlen(values[num_values].value);\n' \
+             '                     num_values++;\n' \
+             '                  }\n' \
+             '                  else\n' \
+             '                     break;\n' \
+             '               }\n' \
+             '\n' \
+             '               /* Build values string */\n' \
+             '               if (num_values > 0)\n' \
+             '               {\n' \
+             '                  buf_len += num_values - 1;\n' \
+             '                  buf_len += strlen(desc);\n' \
+             '\n' \
+             '                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));\n' \
+             '                  if (!values_buf[i])\n' \
+             '                     goto error;\n' \
+             '\n' \
+             '                  strcpy(values_buf[i], desc);\n' \
+             '                  strcat(values_buf[i], "; ");\n' \
+             '\n' \
+             '                  /* Default value goes first */\n' \
+             '                  strcat(values_buf[i], values[default_index].value);\n' \
+             '\n' \
+             '                  /* Add remaining values */\n' \
+             '                  for (j = 0; j < num_values; j++)\n' \
+             '                  {\n' \
+             '                     if (j != default_index)\n' \
+             '                     {\n' \
+             '                        strcat(values_buf[i], "|");\n' \
+             '                        strcat(values_buf[i], values[j].value);\n' \
+             '                     }\n' \
+             '                  }\n' \
+             '               }\n' \
+             '            }\n' \
+             '\n' \
+             '            variables[option_index].key   = key;\n' \
+             '            variables[option_index].value = values_buf[i];\n' \
+             '            option_index++;\n' \
+             '         }\n' \
+             '\n' \
+             '         /* Set variables */\n' \
+             '         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);\n' \
+             '      }\n' \
+             '\n' \
+             'error:\n' \
+             '      /* Clean up */\n' \
+             '\n' \
+             '      if (option_v1_defs_us)\n' \
+             '      {\n' \
+             '         free(option_v1_defs_us);\n' \
+             '         option_v1_defs_us = NULL;\n' \
+             '      }\n' \
+             '\n' \
+             '#ifndef HAVE_NO_LANGEXTRA\n' \
+             '      if (option_v1_defs_intl)\n' \
+             '      {\n' \
+             '         free(option_v1_defs_intl);\n' \
+             '         option_v1_defs_intl = NULL;\n' \
+             '      }\n' \
+             '#endif\n' \
+             '\n' \
+             '      if (values_buf)\n' \
+             '      {\n' \
+             '         for (i = 0; i < num_options; i++)\n' \
+             '         {\n' \
+             '            if (values_buf[i])\n' \
+             '            {\n' \
+             '               free(values_buf[i]);\n' \
+             '               values_buf[i] = NULL;\n' \
+             '            }\n' \
+             '         }\n' \
+             '\n' \
+             '         free(values_buf);\n' \
+             '         values_buf = NULL;\n' \
+             '      }\n' \
+             '\n' \
+             '      if (variables)\n' \
+             '      {\n' \
+             '         free(variables);\n' \
+             '         variables = NULL;\n' \
+             '      }\n' \
+             '   }\n' \
+             '}\n' \
+             '\n' \
+             '#ifdef __cplusplus\n' \
+             '}\n' \
+             '#endif'
+
+   struct_groups = cor.p_struct.finditer(struct_text)
+   out_text = struct_text
+
+   for construct in struct_groups:
+      repl_text = ''
+      declaration = construct.group(1)
+      struct_match = cor.p_type_name.search(declaration)
+      if struct_match:
+         if struct_match.group(3):
+            struct_type_name_lang = struct_match.group(1, 2, 3)
+            declaration_end = declaration[struct_match.end(1):]
+         elif struct_match.group(4):
+            struct_type_name_lang = struct_match.group(1, 2, 4)
+            declaration_end = declaration[struct_match.end(1):]
+         else:
+            struct_type_name_lang = sum((struct_match.group(1, 2), ('_us',)), ())
+            declaration_end = f'{declaration[struct_match.end(1):struct_match.end(2)]}_us' \
+                              f'{declaration[struct_match.end(2):]}'
+      else:
+         return -1
+
+      if 'retro_core_option_definition' == struct_type_name_lang[0]:
+         import shutil
+         shutil.copy(file_name, file_name + '.v1')
+         new_declaration = f'\nstruct retro_core_option_v2_category option_cats{struct_type_name_lang[2]}[] = ' \
+                           '{\n   { NULL, NULL, NULL },\n' \
+                           '};\n\n' \
+                           + declaration[:struct_match.start(1)] + \
+                           'retro_core_option_v2_definition' \
+                           + declaration_end
+         offset = construct.start(0)
+         repl_text = repl_text + cor.re.sub(cor.re.escape(declaration), new_declaration,
+                                            construct.group(0)[:construct.start(2) - offset])
+         content = construct.group(2)
+         new_content = cor.p_option.sub(replace_option, content)
+
+         repl_text = repl_text + new_content + cor.re.sub(r'{\s*NULL,\s*NULL,\s*NULL,\s*{\{0}},\s*NULL\s*},\s*};',
+                                                          '{ NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },\n};'
+                                                          '\n\nstruct retro_core_options_v2 options' +
+                                                          struct_type_name_lang[2] + ' = {\n'
+                                                                                     f'   option_cats{struct_type_name_lang[2]},\n'
+                                                                                     f'   option_defs{struct_type_name_lang[2]}\n'
+                                                                                     '};',
+                                                          construct.group(0)[construct.end(2) - offset:])
+         out_text = cor.re.sub(cor.re.escape(construct.group(0)), repl_text, out_text)
+      else:
+         return -2
+   with open(file_name, 'w', encoding='utf-8') as code_file:
+      out_text = cor.re.sub(cor.re.escape(comment_v1), comment_v2, out_text)
+      intl = p_intl.search(out_text)
+      if intl:
+         new_intl = out_text[:intl.start(1)] \
+                    + 'struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST]' \
+                    + out_text[intl.end(1):intl.start(2)] \
+                    + '\n   &options_us, /* RETRO_LANGUAGE_ENGLISH */\n' \
+                      '   &options_ja,      /* RETRO_LANGUAGE_JAPANESE */\n' \
+                      '   &options_fr,      /* RETRO_LANGUAGE_FRENCH */\n' \
+                      '   &options_es,      /* RETRO_LANGUAGE_SPANISH */\n' \
+                      '   &options_de,      /* RETRO_LANGUAGE_GERMAN */\n' \
+                      '   &options_it,      /* RETRO_LANGUAGE_ITALIAN */\n' \
+                      '   &options_nl,      /* RETRO_LANGUAGE_DUTCH */\n' \
+                      '   &options_pt_br,   /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */\n' \
+                      '   &options_pt_pt,   /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */\n' \
+                      '   &options_ru,      /* RETRO_LANGUAGE_RUSSIAN */\n' \
+                      '   &options_ko,      /* RETRO_LANGUAGE_KOREAN */\n' \
+                      '   &options_cht,     /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */\n' \
+                      '   &options_chs,     /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */\n' \
+                      '   &options_eo,      /* RETRO_LANGUAGE_ESPERANTO */\n' \
+                      '   &options_pl,      /* RETRO_LANGUAGE_POLISH */\n' \
+                      '   &options_vn,      /* RETRO_LANGUAGE_VIETNAMESE */\n' \
+                      '   &options_ar,      /* RETRO_LANGUAGE_ARABIC */\n' \
+                      '   &options_el,      /* RETRO_LANGUAGE_GREEK */\n' \
+                      '   &options_tr,      /* RETRO_LANGUAGE_TURKISH */\n' \
+                      '   &options_sv,      /* RETRO_LANGUAGE_SLOVAK */\n' \
+                      '   &options_fa,      /* RETRO_LANGUAGE_PERSIAN */\n' \
+                      '   &options_he,      /* RETRO_LANGUAGE_HEBREW */\n' \
+                      '   &options_ast,     /* RETRO_LANGUAGE_ASTURIAN */\n' \
+                      '   &options_fi,      /* RETRO_LANGUAGE_FINNISH */\n' \
+                    + out_text[intl.end(2):]
+         out_text = p_set.sub(new_set, new_intl)
+      else:
+         out_text = p_set.sub(new_set, out_text)
+      code_file.write(out_text)
+
+   return 1
+
+
+# --------------------          MAIN          -------------------- #
+
+if __name__ == '__main__':
+   try:
+      if os.path.isfile(sys.argv[1]):
+         _temp = os.path.dirname(sys.argv[1])
+      else:
+         _temp = sys.argv[1]
+      while _temp.endswith('/') or _temp.endswith('\\'):
+         _temp = _temp[:-1]
+      DIR_PATH = _temp
+   except IndexError:
+      DIR_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+      print("No path provided, assuming parent directory:\n" + DIR_PATH)
+
+   H_FILE_PATH = os.path.join(DIR_PATH, 'libretro_core_options.h')
+   INTL_FILE_PATH = os.path.join(DIR_PATH, 'libretro_core_options_intl.h')
+
+   for file in (H_FILE_PATH, INTL_FILE_PATH):
+      if os.path.isfile(file):
+         with open(file, 'r+', encoding='utf-8') as h_file:
+            text = h_file.read()
+            try:
+               test = create_v2_code_file(text, file)
+            except Exception as e:
+               print(e)
+               test = -1
+            if -1 > test:
+               print('Your file looks like it already is v2? (' + file + ')')
+               continue
+            if 0 > test:
+               print('An error occured! Please make sure to use the complete v1 struct! (' + file + ')')
+               continue
+      else:
+         print(file + ' not found.')

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -432,6 +432,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 void retro_set_environment(retro_environment_t cb)
 {
    struct retro_vfs_interface_info vfs_iface_info;
+   static bool libretro_supports_option_categories = false;
    static const struct retro_controller_description port[] = {
 		{ "Gamepad Modern", RETROPAD_MODERN },
 		{ "Gamepad Classic", RETROPAD_CLASSIC },
@@ -446,7 +447,9 @@ void retro_set_environment(retro_environment_t cb)
 
 	environ_cb = cb;
 
-   libretro_set_core_options(environ_cb);
+   libretro_set_core_options(environ_cb,
+         &libretro_supports_option_categories);
+
 	cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
 
    vfs_iface_info.required_interface_version = 1;

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -7,6 +7,10 @@
 #include <libretro.h>
 #include <retro_inline.h>
 
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -26,11 +30,19 @@ extern "C" {
  * - Will be used as a fallback for any missing entries in
  *   frontend language definition */
 
-struct retro_core_option_definition option_defs_us[] = {
+
+struct retro_core_option_v2_category option_cats_us[] = {
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
    {
       "prboom-resolution",
-      "Internal Resolution (Restart)",
-      "Configure the resolution. Requires a restart.",
+      "Internal resolution (Restart Required)",
+      NULL,
+      "Configure the resolution.",
+      NULL,
+      NULL,
       {
          { "320x200",   NULL },
          { "640x400",   NULL },
@@ -47,7 +59,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "prboom-mouse_on",
       "Mouse Active When Using Gamepad",
+      NULL,
       "Allows you to use mouse inputs even when User 1's device type isn't set to 'RetroKeyboard/Mouse'.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -58,7 +73,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "prboom-find_recursive_on",
       "Look on Parent Folders for IWADs",
+      NULL,
       "Scans parent folders for IWADs. NOTE: You need to disable this if you want to run SIGIL.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -69,7 +87,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "prboom-rumble",
       "Rumble Effects",
+      NULL,
       "Enables haptic feedback when using a rumble-equipped gamepad.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -80,7 +101,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "prboom-analog_deadzone",
       "Analog Deadzone (Percent)",
+      NULL,
       "Sets the deadzone of the gamepad analog sticks when the input device type is set to 'Gamepad Modern'.",
+      NULL,
+      NULL,
       {
          { "0",  NULL },
          { "5",  NULL },
@@ -97,7 +121,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "prboom-purge_limit",
       "Cache Size",
+      NULL,
       "Sets a limit on the size of the memory pool used to cache game assets. Small values may cause stuttering when navigating large maps.",
+      NULL,
+      NULL,
       {
          { "8",   "8 MB" },
          { "12",  "12 MB" },
@@ -113,44 +140,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "16"
    },
 #endif
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
 };
 
-/* RETRO_LANGUAGE_JAPANESE */
-
-/* RETRO_LANGUAGE_FRENCH */
-
-/* RETRO_LANGUAGE_SPANISH */
-
-/* RETRO_LANGUAGE_GERMAN */
-
-/* RETRO_LANGUAGE_ITALIAN */
-
-/* RETRO_LANGUAGE_DUTCH */
-
-/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-
-/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-
-/* RETRO_LANGUAGE_RUSSIAN */
-
-/* RETRO_LANGUAGE_KOREAN */
-
-/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-
-/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-
-/* RETRO_LANGUAGE_ESPERANTO */
-
-/* RETRO_LANGUAGE_POLISH */
-
-/* RETRO_LANGUAGE_VIETNAMESE */
-
-/* RETRO_LANGUAGE_ARABIC */
-
-/* RETRO_LANGUAGE_GREEK */
-
-/* RETRO_LANGUAGE_TURKISH */
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
+};
 
 /*
  ********************************
@@ -158,27 +154,34 @@ struct retro_core_option_definition option_defs_us[] = {
  ********************************
 */
 
-struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
-   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
-   NULL,           /* RETRO_LANGUAGE_JAPANESE */
-   NULL,           /* RETRO_LANGUAGE_FRENCH */
-   NULL,           /* RETRO_LANGUAGE_SPANISH */
-   NULL,           /* RETRO_LANGUAGE_GERMAN */
-   NULL,           /* RETRO_LANGUAGE_ITALIAN */
-   NULL,           /* RETRO_LANGUAGE_DUTCH */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
-   NULL,           /* RETRO_LANGUAGE_KOREAN */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
-   NULL,           /* RETRO_LANGUAGE_POLISH */
-   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
-   NULL,           /* RETRO_LANGUAGE_ARABIC */
-   NULL,           /* RETRO_LANGUAGE_GREEK */
-   NULL,           /* RETRO_LANGUAGE_TURKISH */
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   &options_ja,      /* RETRO_LANGUAGE_JAPANESE */
+   &options_fr,      /* RETRO_LANGUAGE_FRENCH */
+   &options_es,      /* RETRO_LANGUAGE_SPANISH */
+   &options_de,      /* RETRO_LANGUAGE_GERMAN */
+   &options_it,      /* RETRO_LANGUAGE_ITALIAN */
+   &options_nl,      /* RETRO_LANGUAGE_DUTCH */
+   &options_pt_br,   /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   &options_pt_pt,   /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   &options_ru,      /* RETRO_LANGUAGE_RUSSIAN */
+   &options_ko,      /* RETRO_LANGUAGE_KOREAN */
+   &options_cht,     /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   &options_chs,     /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   &options_eo,      /* RETRO_LANGUAGE_ESPERANTO */
+   &options_pl,      /* RETRO_LANGUAGE_POLISH */
+   &options_vn,      /* RETRO_LANGUAGE_VIETNAMESE */
+   &options_ar,      /* RETRO_LANGUAGE_ARABIC */
+   &options_el,      /* RETRO_LANGUAGE_GREEK */
+   &options_tr,      /* RETRO_LANGUAGE_TURKISH */
+   &options_sv,      /* RETRO_LANGUAGE_SLOVAK */
+   &options_fa,      /* RETRO_LANGUAGE_PERSIAN */
+   &options_he,      /* RETRO_LANGUAGE_HEBREW */
+   &options_ast,     /* RETRO_LANGUAGE_ASTURIAN */
+   &options_fi,      /* RETRO_LANGUAGE_FINNISH */
 };
+#endif
 
 /*
  ********************************
@@ -193,35 +196,61 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
  *   be as painless as possible for core devs)
  */
 
-static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
 {
-   unsigned version = 0;
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
 
-   if (!environ_cb)
+   if (!environ_cb || !categories_supported)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
-   {
-      struct retro_core_options_intl core_options_intl;
-      unsigned language = 0;
+   *categories_supported = false;
 
-      core_options_intl.us    = option_defs_us;
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_v2_intl core_options_intl;
+
+      core_options_intl.us    = &options_us;
       core_options_intl.local = NULL;
 
       if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
           (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
-         core_options_intl.local = option_defs_intl[language];
+         core_options_intl.local = options_intl[language];
 
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
+#else
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
+#endif
    }
    else
    {
-      size_t i;
+      size_t i, j;
+      size_t option_index              = 0;
       size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
       struct retro_variable *variables = NULL;
       char **values_buf                = NULL;
 
-      /* Determine number of options */
+      /* Determine total number of options */
       while (true)
       {
          if (option_defs_us[num_options].key)
@@ -230,86 +259,187 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             break;
       }
 
-      /* Allocate arrays */
-      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
-      values_buf = (char **)calloc(num_options, sizeof(char *));
-
-      if (!variables || !values_buf)
-         goto error;
-
-      /* Copy parameters from option_defs_us array */
-      for (i = 0; i < num_options; i++)
+      if (version >= 1)
       {
-         const char *key                        = option_defs_us[i].key;
-         const char *desc                       = option_defs_us[i].desc;
-         const char *default_value              = option_defs_us[i].default_value;
-         struct retro_core_option_value *values = option_defs_us[i].values;
-         size_t buf_len                         = 3;
-         size_t default_index                   = 0;
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
 
-         values_buf[i] = NULL;
-
-         if (desc)
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
          {
-            size_t num_values = 0;
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
 
-            /* Determine number of values */
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
             while (true)
             {
-               if (values[num_values].value)
-               {
-                  /* Check if this is the default value */
-                  if (default_value)
-                     if (strcmp(values[num_values].value, default_value) == 0)
-                        default_index = num_values;
-
-                  buf_len += strlen(values[num_values].value);
-                  num_values++;
-               }
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
                else
                   break;
             }
 
-            /* Build values string */
-            if (num_values > 1)
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
             {
-               size_t j;
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
 
-               buf_len += num_values - 1;
-               buf_len += strlen(desc);
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
 
-               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
-               if (!values_buf[i])
-                  goto error;
-
-               strcpy(values_buf[i], desc);
-               strcat(values_buf[i], "; ");
-
-               /* Default value goes first */
-               strcat(values_buf[i], values[default_index].value);
-
-               /* Add remaining values */
-               for (j = 0; j < num_values; j++)
+               /* Values must be copied individually... */
+               while (option_values->value)
                {
-                  if (j != default_index)
-                  {
-                     strcat(values_buf[i], "|");
-                     strcat(values_buf[i], values[j].value);
-                  }
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
                }
             }
          }
 
-         variables[i].key   = key;
-         variables[i].value = values_buf[i];
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
       }
-      
-      /* Set variables */
-      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      }
 
 error:
-
       /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
       if (values_buf)
       {
          for (i = 0; i < num_options; i++)
@@ -338,3 +468,4 @@ error:
 #endif
 
 #endif
+

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -1,0 +1,5465 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+/* RETRO_LANGUAGE_AR */
+
+#define PRBOOM_RESOLUTION_LABEL_AR NULL
+#define PRBOOM_RESOLUTION_INFO_0_AR NULL
+#define OPTION_VAL_320X200_AR NULL
+#define OPTION_VAL_640X400_AR NULL
+#define OPTION_VAL_960X600_AR NULL
+#define OPTION_VAL_1280X800_AR NULL
+#define OPTION_VAL_1600X1000_AR NULL
+#define OPTION_VAL_1920X1200_AR NULL
+#define OPTION_VAL_2240X1400_AR NULL
+#define OPTION_VAL_2560X1600_AR NULL
+#define PRBOOM_MOUSE_ON_LABEL_AR NULL
+#define PRBOOM_MOUSE_ON_INFO_0_AR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_AR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_AR NULL
+#define PRBOOM_RUMBLE_LABEL_AR NULL
+#define PRBOOM_RUMBLE_INFO_0_AR NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_AR NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_AR NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_AR NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_AR NULL
+#define OPTION_VAL_8_AR NULL
+#define OPTION_VAL_12_AR NULL
+#define OPTION_VAL_16_AR NULL
+#define OPTION_VAL_24_AR NULL
+#define OPTION_VAL_32_AR NULL
+#define OPTION_VAL_48_AR NULL
+#define OPTION_VAL_64_AR NULL
+#define OPTION_VAL_128_AR NULL
+#define OPTION_VAL_256_AR NULL
+
+struct retro_core_option_v2_category option_cats_ar[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ar[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_AR,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_AR,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_AR },
+         { "640x400",   OPTION_VAL_640X400_AR },
+         { "960x600",   OPTION_VAL_960X600_AR },
+         { "1280x800",  OPTION_VAL_1280X800_AR },
+         { "1600x1000", OPTION_VAL_1600X1000_AR },
+         { "1920x1200", OPTION_VAL_1920X1200_AR },
+         { "2240x1400", OPTION_VAL_2240X1400_AR },
+         { "2560x1600", OPTION_VAL_2560X1600_AR },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_AR,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_AR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_AR,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_AR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_AR,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_AR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_AR,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_AR,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_AR,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_AR,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_AR },
+         { "12",  OPTION_VAL_12_AR },
+         { "16",  OPTION_VAL_16_AR },
+         { "24",  OPTION_VAL_24_AR },
+         { "32",  OPTION_VAL_32_AR },
+         { "48",  OPTION_VAL_48_AR },
+         { "64",  OPTION_VAL_64_AR },
+         { "128", OPTION_VAL_128_AR },
+         { "256", OPTION_VAL_256_AR },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ar = {
+   option_cats_ar,
+   option_defs_ar
+};
+
+/* RETRO_LANGUAGE_AST */
+
+#define PRBOOM_RESOLUTION_LABEL_AST NULL
+#define PRBOOM_RESOLUTION_INFO_0_AST NULL
+#define OPTION_VAL_320X200_AST NULL
+#define OPTION_VAL_640X400_AST NULL
+#define OPTION_VAL_960X600_AST NULL
+#define OPTION_VAL_1280X800_AST NULL
+#define OPTION_VAL_1600X1000_AST NULL
+#define OPTION_VAL_1920X1200_AST NULL
+#define OPTION_VAL_2240X1400_AST NULL
+#define OPTION_VAL_2560X1600_AST NULL
+#define PRBOOM_MOUSE_ON_LABEL_AST NULL
+#define PRBOOM_MOUSE_ON_INFO_0_AST NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_AST NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_AST NULL
+#define PRBOOM_RUMBLE_LABEL_AST "Efeutos del vibrador"
+#define PRBOOM_RUMBLE_INFO_0_AST NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_AST NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_AST NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_AST "Tamañu de la caché"
+#define PRBOOM_PURGE_LIMIT_INFO_0_AST NULL
+#define OPTION_VAL_8_AST NULL
+#define OPTION_VAL_12_AST NULL
+#define OPTION_VAL_16_AST NULL
+#define OPTION_VAL_24_AST NULL
+#define OPTION_VAL_32_AST NULL
+#define OPTION_VAL_48_AST NULL
+#define OPTION_VAL_64_AST NULL
+#define OPTION_VAL_128_AST NULL
+#define OPTION_VAL_256_AST NULL
+
+struct retro_core_option_v2_category option_cats_ast[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ast[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_AST,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_AST,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_AST },
+         { "640x400",   OPTION_VAL_640X400_AST },
+         { "960x600",   OPTION_VAL_960X600_AST },
+         { "1280x800",  OPTION_VAL_1280X800_AST },
+         { "1600x1000", OPTION_VAL_1600X1000_AST },
+         { "1920x1200", OPTION_VAL_1920X1200_AST },
+         { "2240x1400", OPTION_VAL_2240X1400_AST },
+         { "2560x1600", OPTION_VAL_2560X1600_AST },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_AST,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_AST,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_AST,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_AST,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_AST,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_AST,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_AST,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_AST,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_AST,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_AST,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_AST },
+         { "12",  OPTION_VAL_12_AST },
+         { "16",  OPTION_VAL_16_AST },
+         { "24",  OPTION_VAL_24_AST },
+         { "32",  OPTION_VAL_32_AST },
+         { "48",  OPTION_VAL_48_AST },
+         { "64",  OPTION_VAL_64_AST },
+         { "128", OPTION_VAL_128_AST },
+         { "256", OPTION_VAL_256_AST },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ast = {
+   option_cats_ast,
+   option_defs_ast
+};
+
+/* RETRO_LANGUAGE_CA */
+
+#define PRBOOM_RESOLUTION_LABEL_CA NULL
+#define PRBOOM_RESOLUTION_INFO_0_CA NULL
+#define OPTION_VAL_320X200_CA NULL
+#define OPTION_VAL_640X400_CA NULL
+#define OPTION_VAL_960X600_CA NULL
+#define OPTION_VAL_1280X800_CA NULL
+#define OPTION_VAL_1600X1000_CA NULL
+#define OPTION_VAL_1920X1200_CA NULL
+#define OPTION_VAL_2240X1400_CA NULL
+#define OPTION_VAL_2560X1600_CA NULL
+#define PRBOOM_MOUSE_ON_LABEL_CA NULL
+#define PRBOOM_MOUSE_ON_INFO_0_CA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_CA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_CA NULL
+#define PRBOOM_RUMBLE_LABEL_CA NULL
+#define PRBOOM_RUMBLE_INFO_0_CA NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_CA NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_CA NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_CA NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_CA NULL
+#define OPTION_VAL_8_CA NULL
+#define OPTION_VAL_12_CA NULL
+#define OPTION_VAL_16_CA NULL
+#define OPTION_VAL_24_CA NULL
+#define OPTION_VAL_32_CA NULL
+#define OPTION_VAL_48_CA NULL
+#define OPTION_VAL_64_CA NULL
+#define OPTION_VAL_128_CA NULL
+#define OPTION_VAL_256_CA NULL
+
+struct retro_core_option_v2_category option_cats_ca[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ca[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_CA,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_CA,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_CA },
+         { "640x400",   OPTION_VAL_640X400_CA },
+         { "960x600",   OPTION_VAL_960X600_CA },
+         { "1280x800",  OPTION_VAL_1280X800_CA },
+         { "1600x1000", OPTION_VAL_1600X1000_CA },
+         { "1920x1200", OPTION_VAL_1920X1200_CA },
+         { "2240x1400", OPTION_VAL_2240X1400_CA },
+         { "2560x1600", OPTION_VAL_2560X1600_CA },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_CA,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_CA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_CA,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_CA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_CA,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_CA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_CA,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_CA,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_CA,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_CA,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_CA },
+         { "12",  OPTION_VAL_12_CA },
+         { "16",  OPTION_VAL_16_CA },
+         { "24",  OPTION_VAL_24_CA },
+         { "32",  OPTION_VAL_32_CA },
+         { "48",  OPTION_VAL_48_CA },
+         { "64",  OPTION_VAL_64_CA },
+         { "128", OPTION_VAL_128_CA },
+         { "256", OPTION_VAL_256_CA },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ca = {
+   option_cats_ca,
+   option_defs_ca
+};
+
+/* RETRO_LANGUAGE_CHS */
+
+#define PRBOOM_RESOLUTION_LABEL_CHS NULL
+#define PRBOOM_RESOLUTION_INFO_0_CHS NULL
+#define OPTION_VAL_320X200_CHS NULL
+#define OPTION_VAL_640X400_CHS NULL
+#define OPTION_VAL_960X600_CHS NULL
+#define OPTION_VAL_1280X800_CHS NULL
+#define OPTION_VAL_1600X1000_CHS NULL
+#define OPTION_VAL_1920X1200_CHS NULL
+#define OPTION_VAL_2240X1400_CHS NULL
+#define OPTION_VAL_2560X1600_CHS NULL
+#define PRBOOM_MOUSE_ON_LABEL_CHS NULL
+#define PRBOOM_MOUSE_ON_INFO_0_CHS NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_CHS NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_CHS NULL
+#define PRBOOM_RUMBLE_LABEL_CHS NULL
+#define PRBOOM_RUMBLE_INFO_0_CHS NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_CHS NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_CHS NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_CHS NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_CHS NULL
+#define OPTION_VAL_8_CHS NULL
+#define OPTION_VAL_12_CHS NULL
+#define OPTION_VAL_16_CHS NULL
+#define OPTION_VAL_24_CHS NULL
+#define OPTION_VAL_32_CHS NULL
+#define OPTION_VAL_48_CHS NULL
+#define OPTION_VAL_64_CHS NULL
+#define OPTION_VAL_128_CHS NULL
+#define OPTION_VAL_256_CHS NULL
+
+struct retro_core_option_v2_category option_cats_chs[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_chs[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_CHS,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_CHS,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_CHS },
+         { "640x400",   OPTION_VAL_640X400_CHS },
+         { "960x600",   OPTION_VAL_960X600_CHS },
+         { "1280x800",  OPTION_VAL_1280X800_CHS },
+         { "1600x1000", OPTION_VAL_1600X1000_CHS },
+         { "1920x1200", OPTION_VAL_1920X1200_CHS },
+         { "2240x1400", OPTION_VAL_2240X1400_CHS },
+         { "2560x1600", OPTION_VAL_2560X1600_CHS },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_CHS,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_CHS,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_CHS,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_CHS,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_CHS,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_CHS,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_CHS,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_CHS,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_CHS,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_CHS,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_CHS },
+         { "12",  OPTION_VAL_12_CHS },
+         { "16",  OPTION_VAL_16_CHS },
+         { "24",  OPTION_VAL_24_CHS },
+         { "32",  OPTION_VAL_32_CHS },
+         { "48",  OPTION_VAL_48_CHS },
+         { "64",  OPTION_VAL_64_CHS },
+         { "128", OPTION_VAL_128_CHS },
+         { "256", OPTION_VAL_256_CHS },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_chs = {
+   option_cats_chs,
+   option_defs_chs
+};
+
+/* RETRO_LANGUAGE_CHT */
+
+#define PRBOOM_RESOLUTION_LABEL_CHT NULL
+#define PRBOOM_RESOLUTION_INFO_0_CHT NULL
+#define OPTION_VAL_320X200_CHT NULL
+#define OPTION_VAL_640X400_CHT NULL
+#define OPTION_VAL_960X600_CHT NULL
+#define OPTION_VAL_1280X800_CHT NULL
+#define OPTION_VAL_1600X1000_CHT NULL
+#define OPTION_VAL_1920X1200_CHT NULL
+#define OPTION_VAL_2240X1400_CHT NULL
+#define OPTION_VAL_2560X1600_CHT NULL
+#define PRBOOM_MOUSE_ON_LABEL_CHT NULL
+#define PRBOOM_MOUSE_ON_INFO_0_CHT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_CHT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_CHT NULL
+#define PRBOOM_RUMBLE_LABEL_CHT NULL
+#define PRBOOM_RUMBLE_INFO_0_CHT NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_CHT NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_CHT NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_CHT NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_CHT NULL
+#define OPTION_VAL_8_CHT NULL
+#define OPTION_VAL_12_CHT NULL
+#define OPTION_VAL_16_CHT NULL
+#define OPTION_VAL_24_CHT NULL
+#define OPTION_VAL_32_CHT NULL
+#define OPTION_VAL_48_CHT NULL
+#define OPTION_VAL_64_CHT NULL
+#define OPTION_VAL_128_CHT NULL
+#define OPTION_VAL_256_CHT NULL
+
+struct retro_core_option_v2_category option_cats_cht[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_cht[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_CHT,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_CHT,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_CHT },
+         { "640x400",   OPTION_VAL_640X400_CHT },
+         { "960x600",   OPTION_VAL_960X600_CHT },
+         { "1280x800",  OPTION_VAL_1280X800_CHT },
+         { "1600x1000", OPTION_VAL_1600X1000_CHT },
+         { "1920x1200", OPTION_VAL_1920X1200_CHT },
+         { "2240x1400", OPTION_VAL_2240X1400_CHT },
+         { "2560x1600", OPTION_VAL_2560X1600_CHT },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_CHT,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_CHT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_CHT,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_CHT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_CHT,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_CHT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_CHT,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_CHT,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_CHT,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_CHT,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_CHT },
+         { "12",  OPTION_VAL_12_CHT },
+         { "16",  OPTION_VAL_16_CHT },
+         { "24",  OPTION_VAL_24_CHT },
+         { "32",  OPTION_VAL_32_CHT },
+         { "48",  OPTION_VAL_48_CHT },
+         { "64",  OPTION_VAL_64_CHT },
+         { "128", OPTION_VAL_128_CHT },
+         { "256", OPTION_VAL_256_CHT },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_cht = {
+   option_cats_cht,
+   option_defs_cht
+};
+
+/* RETRO_LANGUAGE_CS */
+
+#define PRBOOM_RESOLUTION_LABEL_CS NULL
+#define PRBOOM_RESOLUTION_INFO_0_CS NULL
+#define OPTION_VAL_320X200_CS NULL
+#define OPTION_VAL_640X400_CS NULL
+#define OPTION_VAL_960X600_CS NULL
+#define OPTION_VAL_1280X800_CS NULL
+#define OPTION_VAL_1600X1000_CS NULL
+#define OPTION_VAL_1920X1200_CS NULL
+#define OPTION_VAL_2240X1400_CS NULL
+#define OPTION_VAL_2560X1600_CS NULL
+#define PRBOOM_MOUSE_ON_LABEL_CS NULL
+#define PRBOOM_MOUSE_ON_INFO_0_CS NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_CS NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_CS NULL
+#define PRBOOM_RUMBLE_LABEL_CS NULL
+#define PRBOOM_RUMBLE_INFO_0_CS NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_CS NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_CS NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_CS NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_CS NULL
+#define OPTION_VAL_8_CS NULL
+#define OPTION_VAL_12_CS NULL
+#define OPTION_VAL_16_CS NULL
+#define OPTION_VAL_24_CS NULL
+#define OPTION_VAL_32_CS NULL
+#define OPTION_VAL_48_CS NULL
+#define OPTION_VAL_64_CS NULL
+#define OPTION_VAL_128_CS NULL
+#define OPTION_VAL_256_CS NULL
+
+struct retro_core_option_v2_category option_cats_cs[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_cs[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_CS,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_CS,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_CS },
+         { "640x400",   OPTION_VAL_640X400_CS },
+         { "960x600",   OPTION_VAL_960X600_CS },
+         { "1280x800",  OPTION_VAL_1280X800_CS },
+         { "1600x1000", OPTION_VAL_1600X1000_CS },
+         { "1920x1200", OPTION_VAL_1920X1200_CS },
+         { "2240x1400", OPTION_VAL_2240X1400_CS },
+         { "2560x1600", OPTION_VAL_2560X1600_CS },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_CS,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_CS,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_CS,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_CS,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_CS,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_CS,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_CS,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_CS,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_CS,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_CS,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_CS },
+         { "12",  OPTION_VAL_12_CS },
+         { "16",  OPTION_VAL_16_CS },
+         { "24",  OPTION_VAL_24_CS },
+         { "32",  OPTION_VAL_32_CS },
+         { "48",  OPTION_VAL_48_CS },
+         { "64",  OPTION_VAL_64_CS },
+         { "128", OPTION_VAL_128_CS },
+         { "256", OPTION_VAL_256_CS },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_cs = {
+   option_cats_cs,
+   option_defs_cs
+};
+
+/* RETRO_LANGUAGE_CY */
+
+#define PRBOOM_RESOLUTION_LABEL_CY NULL
+#define PRBOOM_RESOLUTION_INFO_0_CY NULL
+#define OPTION_VAL_320X200_CY NULL
+#define OPTION_VAL_640X400_CY NULL
+#define OPTION_VAL_960X600_CY NULL
+#define OPTION_VAL_1280X800_CY NULL
+#define OPTION_VAL_1600X1000_CY NULL
+#define OPTION_VAL_1920X1200_CY NULL
+#define OPTION_VAL_2240X1400_CY NULL
+#define OPTION_VAL_2560X1600_CY NULL
+#define PRBOOM_MOUSE_ON_LABEL_CY NULL
+#define PRBOOM_MOUSE_ON_INFO_0_CY NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_CY NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_CY NULL
+#define PRBOOM_RUMBLE_LABEL_CY NULL
+#define PRBOOM_RUMBLE_INFO_0_CY NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_CY NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_CY NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_CY NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_CY NULL
+#define OPTION_VAL_8_CY NULL
+#define OPTION_VAL_12_CY NULL
+#define OPTION_VAL_16_CY NULL
+#define OPTION_VAL_24_CY NULL
+#define OPTION_VAL_32_CY NULL
+#define OPTION_VAL_48_CY NULL
+#define OPTION_VAL_64_CY NULL
+#define OPTION_VAL_128_CY NULL
+#define OPTION_VAL_256_CY NULL
+
+struct retro_core_option_v2_category option_cats_cy[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_cy[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_CY,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_CY,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_CY },
+         { "640x400",   OPTION_VAL_640X400_CY },
+         { "960x600",   OPTION_VAL_960X600_CY },
+         { "1280x800",  OPTION_VAL_1280X800_CY },
+         { "1600x1000", OPTION_VAL_1600X1000_CY },
+         { "1920x1200", OPTION_VAL_1920X1200_CY },
+         { "2240x1400", OPTION_VAL_2240X1400_CY },
+         { "2560x1600", OPTION_VAL_2560X1600_CY },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_CY,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_CY,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_CY,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_CY,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_CY,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_CY,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_CY,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_CY,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_CY,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_CY,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_CY },
+         { "12",  OPTION_VAL_12_CY },
+         { "16",  OPTION_VAL_16_CY },
+         { "24",  OPTION_VAL_24_CY },
+         { "32",  OPTION_VAL_32_CY },
+         { "48",  OPTION_VAL_48_CY },
+         { "64",  OPTION_VAL_64_CY },
+         { "128", OPTION_VAL_128_CY },
+         { "256", OPTION_VAL_256_CY },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_cy = {
+   option_cats_cy,
+   option_defs_cy
+};
+
+/* RETRO_LANGUAGE_DA */
+
+#define PRBOOM_RESOLUTION_LABEL_DA NULL
+#define PRBOOM_RESOLUTION_INFO_0_DA NULL
+#define OPTION_VAL_320X200_DA NULL
+#define OPTION_VAL_640X400_DA NULL
+#define OPTION_VAL_960X600_DA NULL
+#define OPTION_VAL_1280X800_DA NULL
+#define OPTION_VAL_1600X1000_DA NULL
+#define OPTION_VAL_1920X1200_DA NULL
+#define OPTION_VAL_2240X1400_DA NULL
+#define OPTION_VAL_2560X1600_DA NULL
+#define PRBOOM_MOUSE_ON_LABEL_DA NULL
+#define PRBOOM_MOUSE_ON_INFO_0_DA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_DA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_DA NULL
+#define PRBOOM_RUMBLE_LABEL_DA NULL
+#define PRBOOM_RUMBLE_INFO_0_DA NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_DA NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_DA NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_DA NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_DA NULL
+#define OPTION_VAL_8_DA NULL
+#define OPTION_VAL_12_DA NULL
+#define OPTION_VAL_16_DA NULL
+#define OPTION_VAL_24_DA NULL
+#define OPTION_VAL_32_DA NULL
+#define OPTION_VAL_48_DA NULL
+#define OPTION_VAL_64_DA NULL
+#define OPTION_VAL_128_DA NULL
+#define OPTION_VAL_256_DA NULL
+
+struct retro_core_option_v2_category option_cats_da[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_da[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_DA,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_DA,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_DA },
+         { "640x400",   OPTION_VAL_640X400_DA },
+         { "960x600",   OPTION_VAL_960X600_DA },
+         { "1280x800",  OPTION_VAL_1280X800_DA },
+         { "1600x1000", OPTION_VAL_1600X1000_DA },
+         { "1920x1200", OPTION_VAL_1920X1200_DA },
+         { "2240x1400", OPTION_VAL_2240X1400_DA },
+         { "2560x1600", OPTION_VAL_2560X1600_DA },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_DA,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_DA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_DA,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_DA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_DA,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_DA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_DA,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_DA,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_DA,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_DA,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_DA },
+         { "12",  OPTION_VAL_12_DA },
+         { "16",  OPTION_VAL_16_DA },
+         { "24",  OPTION_VAL_24_DA },
+         { "32",  OPTION_VAL_32_DA },
+         { "48",  OPTION_VAL_48_DA },
+         { "64",  OPTION_VAL_64_DA },
+         { "128", OPTION_VAL_128_DA },
+         { "256", OPTION_VAL_256_DA },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_da = {
+   option_cats_da,
+   option_defs_da
+};
+
+/* RETRO_LANGUAGE_DE */
+
+#define PRBOOM_RESOLUTION_LABEL_DE NULL
+#define PRBOOM_RESOLUTION_INFO_0_DE NULL
+#define OPTION_VAL_320X200_DE NULL
+#define OPTION_VAL_640X400_DE NULL
+#define OPTION_VAL_960X600_DE NULL
+#define OPTION_VAL_1280X800_DE NULL
+#define OPTION_VAL_1600X1000_DE NULL
+#define OPTION_VAL_1920X1200_DE NULL
+#define OPTION_VAL_2240X1400_DE NULL
+#define OPTION_VAL_2560X1600_DE NULL
+#define PRBOOM_MOUSE_ON_LABEL_DE NULL
+#define PRBOOM_MOUSE_ON_INFO_0_DE NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_DE NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_DE NULL
+#define PRBOOM_RUMBLE_LABEL_DE NULL
+#define PRBOOM_RUMBLE_INFO_0_DE NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_DE NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_DE NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_DE NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_DE NULL
+#define OPTION_VAL_8_DE NULL
+#define OPTION_VAL_12_DE NULL
+#define OPTION_VAL_16_DE NULL
+#define OPTION_VAL_24_DE NULL
+#define OPTION_VAL_32_DE NULL
+#define OPTION_VAL_48_DE NULL
+#define OPTION_VAL_64_DE NULL
+#define OPTION_VAL_128_DE NULL
+#define OPTION_VAL_256_DE NULL
+
+struct retro_core_option_v2_category option_cats_de[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_de[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_DE,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_DE,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_DE },
+         { "640x400",   OPTION_VAL_640X400_DE },
+         { "960x600",   OPTION_VAL_960X600_DE },
+         { "1280x800",  OPTION_VAL_1280X800_DE },
+         { "1600x1000", OPTION_VAL_1600X1000_DE },
+         { "1920x1200", OPTION_VAL_1920X1200_DE },
+         { "2240x1400", OPTION_VAL_2240X1400_DE },
+         { "2560x1600", OPTION_VAL_2560X1600_DE },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_DE,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_DE,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_DE,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_DE,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_DE,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_DE,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_DE,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_DE,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_DE,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_DE,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_DE },
+         { "12",  OPTION_VAL_12_DE },
+         { "16",  OPTION_VAL_16_DE },
+         { "24",  OPTION_VAL_24_DE },
+         { "32",  OPTION_VAL_32_DE },
+         { "48",  OPTION_VAL_48_DE },
+         { "64",  OPTION_VAL_64_DE },
+         { "128", OPTION_VAL_128_DE },
+         { "256", OPTION_VAL_256_DE },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_de = {
+   option_cats_de,
+   option_defs_de
+};
+
+/* RETRO_LANGUAGE_EL */
+
+#define PRBOOM_RESOLUTION_LABEL_EL NULL
+#define PRBOOM_RESOLUTION_INFO_0_EL NULL
+#define OPTION_VAL_320X200_EL NULL
+#define OPTION_VAL_640X400_EL NULL
+#define OPTION_VAL_960X600_EL NULL
+#define OPTION_VAL_1280X800_EL NULL
+#define OPTION_VAL_1600X1000_EL NULL
+#define OPTION_VAL_1920X1200_EL NULL
+#define OPTION_VAL_2240X1400_EL NULL
+#define OPTION_VAL_2560X1600_EL NULL
+#define PRBOOM_MOUSE_ON_LABEL_EL NULL
+#define PRBOOM_MOUSE_ON_INFO_0_EL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_EL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_EL NULL
+#define PRBOOM_RUMBLE_LABEL_EL NULL
+#define PRBOOM_RUMBLE_INFO_0_EL NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_EL NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_EL NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_EL NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_EL NULL
+#define OPTION_VAL_8_EL NULL
+#define OPTION_VAL_12_EL NULL
+#define OPTION_VAL_16_EL NULL
+#define OPTION_VAL_24_EL NULL
+#define OPTION_VAL_32_EL NULL
+#define OPTION_VAL_48_EL NULL
+#define OPTION_VAL_64_EL NULL
+#define OPTION_VAL_128_EL NULL
+#define OPTION_VAL_256_EL NULL
+
+struct retro_core_option_v2_category option_cats_el[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_el[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_EL,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_EL,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_EL },
+         { "640x400",   OPTION_VAL_640X400_EL },
+         { "960x600",   OPTION_VAL_960X600_EL },
+         { "1280x800",  OPTION_VAL_1280X800_EL },
+         { "1600x1000", OPTION_VAL_1600X1000_EL },
+         { "1920x1200", OPTION_VAL_1920X1200_EL },
+         { "2240x1400", OPTION_VAL_2240X1400_EL },
+         { "2560x1600", OPTION_VAL_2560X1600_EL },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_EL,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_EL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_EL,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_EL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_EL,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_EL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_EL,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_EL,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_EL,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_EL,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_EL },
+         { "12",  OPTION_VAL_12_EL },
+         { "16",  OPTION_VAL_16_EL },
+         { "24",  OPTION_VAL_24_EL },
+         { "32",  OPTION_VAL_32_EL },
+         { "48",  OPTION_VAL_48_EL },
+         { "64",  OPTION_VAL_64_EL },
+         { "128", OPTION_VAL_128_EL },
+         { "256", OPTION_VAL_256_EL },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_el = {
+   option_cats_el,
+   option_defs_el
+};
+
+/* RETRO_LANGUAGE_EO */
+
+#define PRBOOM_RESOLUTION_LABEL_EO NULL
+#define PRBOOM_RESOLUTION_INFO_0_EO NULL
+#define OPTION_VAL_320X200_EO NULL
+#define OPTION_VAL_640X400_EO NULL
+#define OPTION_VAL_960X600_EO NULL
+#define OPTION_VAL_1280X800_EO NULL
+#define OPTION_VAL_1600X1000_EO NULL
+#define OPTION_VAL_1920X1200_EO NULL
+#define OPTION_VAL_2240X1400_EO NULL
+#define OPTION_VAL_2560X1600_EO NULL
+#define PRBOOM_MOUSE_ON_LABEL_EO NULL
+#define PRBOOM_MOUSE_ON_INFO_0_EO NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_EO NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_EO NULL
+#define PRBOOM_RUMBLE_LABEL_EO NULL
+#define PRBOOM_RUMBLE_INFO_0_EO NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_EO NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_EO NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_EO NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_EO NULL
+#define OPTION_VAL_8_EO NULL
+#define OPTION_VAL_12_EO NULL
+#define OPTION_VAL_16_EO NULL
+#define OPTION_VAL_24_EO NULL
+#define OPTION_VAL_32_EO NULL
+#define OPTION_VAL_48_EO NULL
+#define OPTION_VAL_64_EO NULL
+#define OPTION_VAL_128_EO NULL
+#define OPTION_VAL_256_EO NULL
+
+struct retro_core_option_v2_category option_cats_eo[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_eo[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_EO,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_EO,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_EO },
+         { "640x400",   OPTION_VAL_640X400_EO },
+         { "960x600",   OPTION_VAL_960X600_EO },
+         { "1280x800",  OPTION_VAL_1280X800_EO },
+         { "1600x1000", OPTION_VAL_1600X1000_EO },
+         { "1920x1200", OPTION_VAL_1920X1200_EO },
+         { "2240x1400", OPTION_VAL_2240X1400_EO },
+         { "2560x1600", OPTION_VAL_2560X1600_EO },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_EO,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_EO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_EO,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_EO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_EO,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_EO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_EO,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_EO,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_EO,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_EO,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_EO },
+         { "12",  OPTION_VAL_12_EO },
+         { "16",  OPTION_VAL_16_EO },
+         { "24",  OPTION_VAL_24_EO },
+         { "32",  OPTION_VAL_32_EO },
+         { "48",  OPTION_VAL_48_EO },
+         { "64",  OPTION_VAL_64_EO },
+         { "128", OPTION_VAL_128_EO },
+         { "256", OPTION_VAL_256_EO },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_eo = {
+   option_cats_eo,
+   option_defs_eo
+};
+
+/* RETRO_LANGUAGE_ES */
+
+#define PRBOOM_RESOLUTION_LABEL_ES "Resolución interna (es necesario reiniciar)"
+#define PRBOOM_RESOLUTION_INFO_0_ES "Cambia la resolución."
+#define OPTION_VAL_320X200_ES "320 × 200"
+#define OPTION_VAL_640X400_ES "640 × 400"
+#define OPTION_VAL_960X600_ES "960 × 600"
+#define OPTION_VAL_1280X800_ES "1280 × 800"
+#define OPTION_VAL_1600X1000_ES "1600 × 1000"
+#define OPTION_VAL_1920X1200_ES "1920 × 1200"
+#define OPTION_VAL_2240X1400_ES "2240 × 1400"
+#define OPTION_VAL_2560X1600_ES "2560 × 1600"
+#define PRBOOM_MOUSE_ON_LABEL_ES "Usar el ratón al utilizar un mando"
+#define PRBOOM_MOUSE_ON_INFO_0_ES "Permite usar entradas de ratón incluso cuando el dispositivo del usuario 1 no sea un RetroKeyboard/Mouse."
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_ES "Buscar IWAD en las carpetas primarias"
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_ES "Busca IWAD en las carpetas primarias. NOTA: Debes desactivar esta opción para poder jugar a SIGIL."
+#define PRBOOM_RUMBLE_LABEL_ES "Vibración"
+#define PRBOOM_RUMBLE_INFO_0_ES "Activa la respuesta háptica al utilizar un mando compatible con vibración."
+#define PRBOOM_ANALOG_DEADZONE_LABEL_ES "Zona muerta analógica (en porcentaje)"
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_ES "Asigna la zona muerta de los sticks analógicos cuando el dispositivo de entrada sea un mando moderno."
+#define PRBOOM_PURGE_LIMIT_LABEL_ES "Tamaño de la caché"
+#define PRBOOM_PURGE_LIMIT_INFO_0_ES "Establece un límite al tamaño de la memoria asignada para almacenar los recursos del juego. Un valor muy bajo puede provocar tirones al jugar en mapas de grandes dimensiones."
+#define OPTION_VAL_8_ES NULL
+#define OPTION_VAL_12_ES NULL
+#define OPTION_VAL_16_ES NULL
+#define OPTION_VAL_24_ES NULL
+#define OPTION_VAL_32_ES NULL
+#define OPTION_VAL_48_ES NULL
+#define OPTION_VAL_64_ES NULL
+#define OPTION_VAL_128_ES NULL
+#define OPTION_VAL_256_ES NULL
+
+struct retro_core_option_v2_category option_cats_es[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_es[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_ES,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_ES,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_ES },
+         { "640x400",   OPTION_VAL_640X400_ES },
+         { "960x600",   OPTION_VAL_960X600_ES },
+         { "1280x800",  OPTION_VAL_1280X800_ES },
+         { "1600x1000", OPTION_VAL_1600X1000_ES },
+         { "1920x1200", OPTION_VAL_1920X1200_ES },
+         { "2240x1400", OPTION_VAL_2240X1400_ES },
+         { "2560x1600", OPTION_VAL_2560X1600_ES },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_ES,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_ES,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_ES,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_ES,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_ES,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_ES,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_ES,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_ES,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_ES,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_ES,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_ES },
+         { "12",  OPTION_VAL_12_ES },
+         { "16",  OPTION_VAL_16_ES },
+         { "24",  OPTION_VAL_24_ES },
+         { "32",  OPTION_VAL_32_ES },
+         { "48",  OPTION_VAL_48_ES },
+         { "64",  OPTION_VAL_64_ES },
+         { "128", OPTION_VAL_128_ES },
+         { "256", OPTION_VAL_256_ES },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_es = {
+   option_cats_es,
+   option_defs_es
+};
+
+/* RETRO_LANGUAGE_FA */
+
+#define PRBOOM_RESOLUTION_LABEL_FA NULL
+#define PRBOOM_RESOLUTION_INFO_0_FA NULL
+#define OPTION_VAL_320X200_FA NULL
+#define OPTION_VAL_640X400_FA NULL
+#define OPTION_VAL_960X600_FA NULL
+#define OPTION_VAL_1280X800_FA NULL
+#define OPTION_VAL_1600X1000_FA NULL
+#define OPTION_VAL_1920X1200_FA NULL
+#define OPTION_VAL_2240X1400_FA NULL
+#define OPTION_VAL_2560X1600_FA NULL
+#define PRBOOM_MOUSE_ON_LABEL_FA NULL
+#define PRBOOM_MOUSE_ON_INFO_0_FA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_FA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_FA NULL
+#define PRBOOM_RUMBLE_LABEL_FA NULL
+#define PRBOOM_RUMBLE_INFO_0_FA NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_FA NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_FA NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_FA NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_FA NULL
+#define OPTION_VAL_8_FA NULL
+#define OPTION_VAL_12_FA NULL
+#define OPTION_VAL_16_FA NULL
+#define OPTION_VAL_24_FA NULL
+#define OPTION_VAL_32_FA NULL
+#define OPTION_VAL_48_FA NULL
+#define OPTION_VAL_64_FA NULL
+#define OPTION_VAL_128_FA NULL
+#define OPTION_VAL_256_FA NULL
+
+struct retro_core_option_v2_category option_cats_fa[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_fa[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_FA,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_FA,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_FA },
+         { "640x400",   OPTION_VAL_640X400_FA },
+         { "960x600",   OPTION_VAL_960X600_FA },
+         { "1280x800",  OPTION_VAL_1280X800_FA },
+         { "1600x1000", OPTION_VAL_1600X1000_FA },
+         { "1920x1200", OPTION_VAL_1920X1200_FA },
+         { "2240x1400", OPTION_VAL_2240X1400_FA },
+         { "2560x1600", OPTION_VAL_2560X1600_FA },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_FA,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_FA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_FA,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_FA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_FA,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_FA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_FA,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_FA,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_FA,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_FA,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_FA },
+         { "12",  OPTION_VAL_12_FA },
+         { "16",  OPTION_VAL_16_FA },
+         { "24",  OPTION_VAL_24_FA },
+         { "32",  OPTION_VAL_32_FA },
+         { "48",  OPTION_VAL_48_FA },
+         { "64",  OPTION_VAL_64_FA },
+         { "128", OPTION_VAL_128_FA },
+         { "256", OPTION_VAL_256_FA },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_fa = {
+   option_cats_fa,
+   option_defs_fa
+};
+
+/* RETRO_LANGUAGE_FI */
+
+#define PRBOOM_RESOLUTION_LABEL_FI NULL
+#define PRBOOM_RESOLUTION_INFO_0_FI "Määritä resoluutio."
+#define OPTION_VAL_320X200_FI NULL
+#define OPTION_VAL_640X400_FI NULL
+#define OPTION_VAL_960X600_FI NULL
+#define OPTION_VAL_1280X800_FI NULL
+#define OPTION_VAL_1600X1000_FI NULL
+#define OPTION_VAL_1920X1200_FI NULL
+#define OPTION_VAL_2240X1400_FI NULL
+#define OPTION_VAL_2560X1600_FI NULL
+#define PRBOOM_MOUSE_ON_LABEL_FI NULL
+#define PRBOOM_MOUSE_ON_INFO_0_FI NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_FI NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_FI NULL
+#define PRBOOM_RUMBLE_LABEL_FI NULL
+#define PRBOOM_RUMBLE_INFO_0_FI NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_FI NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_FI NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_FI "Välimuistin koko"
+#define PRBOOM_PURGE_LIMIT_INFO_0_FI NULL
+#define OPTION_VAL_8_FI "8 Mt"
+#define OPTION_VAL_12_FI "12 Mt"
+#define OPTION_VAL_16_FI "16 Mt"
+#define OPTION_VAL_24_FI "24 Mt"
+#define OPTION_VAL_32_FI "32 Mt"
+#define OPTION_VAL_48_FI "48 Mt"
+#define OPTION_VAL_64_FI "64 Mt"
+#define OPTION_VAL_128_FI "128 Mt"
+#define OPTION_VAL_256_FI "256 Mt"
+
+struct retro_core_option_v2_category option_cats_fi[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_fi[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_FI,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_FI,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_FI },
+         { "640x400",   OPTION_VAL_640X400_FI },
+         { "960x600",   OPTION_VAL_960X600_FI },
+         { "1280x800",  OPTION_VAL_1280X800_FI },
+         { "1600x1000", OPTION_VAL_1600X1000_FI },
+         { "1920x1200", OPTION_VAL_1920X1200_FI },
+         { "2240x1400", OPTION_VAL_2240X1400_FI },
+         { "2560x1600", OPTION_VAL_2560X1600_FI },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_FI,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_FI,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_FI,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_FI,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_FI,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_FI,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_FI,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_FI,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_FI,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_FI,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_FI },
+         { "12",  OPTION_VAL_12_FI },
+         { "16",  OPTION_VAL_16_FI },
+         { "24",  OPTION_VAL_24_FI },
+         { "32",  OPTION_VAL_32_FI },
+         { "48",  OPTION_VAL_48_FI },
+         { "64",  OPTION_VAL_64_FI },
+         { "128", OPTION_VAL_128_FI },
+         { "256", OPTION_VAL_256_FI },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_fi = {
+   option_cats_fi,
+   option_defs_fi
+};
+
+/* RETRO_LANGUAGE_FR */
+
+#define PRBOOM_RESOLUTION_LABEL_FR NULL
+#define PRBOOM_RESOLUTION_INFO_0_FR NULL
+#define OPTION_VAL_320X200_FR NULL
+#define OPTION_VAL_640X400_FR NULL
+#define OPTION_VAL_960X600_FR NULL
+#define OPTION_VAL_1280X800_FR NULL
+#define OPTION_VAL_1600X1000_FR NULL
+#define OPTION_VAL_1920X1200_FR NULL
+#define OPTION_VAL_2240X1400_FR NULL
+#define OPTION_VAL_2560X1600_FR NULL
+#define PRBOOM_MOUSE_ON_LABEL_FR NULL
+#define PRBOOM_MOUSE_ON_INFO_0_FR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_FR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_FR NULL
+#define PRBOOM_RUMBLE_LABEL_FR NULL
+#define PRBOOM_RUMBLE_INFO_0_FR NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_FR NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_FR NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_FR NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_FR NULL
+#define OPTION_VAL_8_FR NULL
+#define OPTION_VAL_12_FR NULL
+#define OPTION_VAL_16_FR NULL
+#define OPTION_VAL_24_FR NULL
+#define OPTION_VAL_32_FR NULL
+#define OPTION_VAL_48_FR NULL
+#define OPTION_VAL_64_FR NULL
+#define OPTION_VAL_128_FR NULL
+#define OPTION_VAL_256_FR NULL
+
+struct retro_core_option_v2_category option_cats_fr[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_fr[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_FR,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_FR,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_FR },
+         { "640x400",   OPTION_VAL_640X400_FR },
+         { "960x600",   OPTION_VAL_960X600_FR },
+         { "1280x800",  OPTION_VAL_1280X800_FR },
+         { "1600x1000", OPTION_VAL_1600X1000_FR },
+         { "1920x1200", OPTION_VAL_1920X1200_FR },
+         { "2240x1400", OPTION_VAL_2240X1400_FR },
+         { "2560x1600", OPTION_VAL_2560X1600_FR },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_FR,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_FR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_FR,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_FR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_FR,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_FR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_FR,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_FR,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_FR,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_FR,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_FR },
+         { "12",  OPTION_VAL_12_FR },
+         { "16",  OPTION_VAL_16_FR },
+         { "24",  OPTION_VAL_24_FR },
+         { "32",  OPTION_VAL_32_FR },
+         { "48",  OPTION_VAL_48_FR },
+         { "64",  OPTION_VAL_64_FR },
+         { "128", OPTION_VAL_128_FR },
+         { "256", OPTION_VAL_256_FR },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_fr = {
+   option_cats_fr,
+   option_defs_fr
+};
+
+/* RETRO_LANGUAGE_GL */
+
+#define PRBOOM_RESOLUTION_LABEL_GL NULL
+#define PRBOOM_RESOLUTION_INFO_0_GL NULL
+#define OPTION_VAL_320X200_GL NULL
+#define OPTION_VAL_640X400_GL NULL
+#define OPTION_VAL_960X600_GL NULL
+#define OPTION_VAL_1280X800_GL NULL
+#define OPTION_VAL_1600X1000_GL NULL
+#define OPTION_VAL_1920X1200_GL NULL
+#define OPTION_VAL_2240X1400_GL NULL
+#define OPTION_VAL_2560X1600_GL NULL
+#define PRBOOM_MOUSE_ON_LABEL_GL NULL
+#define PRBOOM_MOUSE_ON_INFO_0_GL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_GL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_GL NULL
+#define PRBOOM_RUMBLE_LABEL_GL NULL
+#define PRBOOM_RUMBLE_INFO_0_GL NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_GL NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_GL NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_GL NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_GL NULL
+#define OPTION_VAL_8_GL NULL
+#define OPTION_VAL_12_GL NULL
+#define OPTION_VAL_16_GL NULL
+#define OPTION_VAL_24_GL NULL
+#define OPTION_VAL_32_GL NULL
+#define OPTION_VAL_48_GL NULL
+#define OPTION_VAL_64_GL NULL
+#define OPTION_VAL_128_GL NULL
+#define OPTION_VAL_256_GL NULL
+
+struct retro_core_option_v2_category option_cats_gl[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_gl[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_GL,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_GL,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_GL },
+         { "640x400",   OPTION_VAL_640X400_GL },
+         { "960x600",   OPTION_VAL_960X600_GL },
+         { "1280x800",  OPTION_VAL_1280X800_GL },
+         { "1600x1000", OPTION_VAL_1600X1000_GL },
+         { "1920x1200", OPTION_VAL_1920X1200_GL },
+         { "2240x1400", OPTION_VAL_2240X1400_GL },
+         { "2560x1600", OPTION_VAL_2560X1600_GL },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_GL,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_GL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_GL,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_GL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_GL,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_GL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_GL,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_GL,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_GL,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_GL,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_GL },
+         { "12",  OPTION_VAL_12_GL },
+         { "16",  OPTION_VAL_16_GL },
+         { "24",  OPTION_VAL_24_GL },
+         { "32",  OPTION_VAL_32_GL },
+         { "48",  OPTION_VAL_48_GL },
+         { "64",  OPTION_VAL_64_GL },
+         { "128", OPTION_VAL_128_GL },
+         { "256", OPTION_VAL_256_GL },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_gl = {
+   option_cats_gl,
+   option_defs_gl
+};
+
+/* RETRO_LANGUAGE_HE */
+
+#define PRBOOM_RESOLUTION_LABEL_HE NULL
+#define PRBOOM_RESOLUTION_INFO_0_HE NULL
+#define OPTION_VAL_320X200_HE NULL
+#define OPTION_VAL_640X400_HE NULL
+#define OPTION_VAL_960X600_HE NULL
+#define OPTION_VAL_1280X800_HE NULL
+#define OPTION_VAL_1600X1000_HE NULL
+#define OPTION_VAL_1920X1200_HE NULL
+#define OPTION_VAL_2240X1400_HE NULL
+#define OPTION_VAL_2560X1600_HE NULL
+#define PRBOOM_MOUSE_ON_LABEL_HE NULL
+#define PRBOOM_MOUSE_ON_INFO_0_HE NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_HE NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_HE NULL
+#define PRBOOM_RUMBLE_LABEL_HE NULL
+#define PRBOOM_RUMBLE_INFO_0_HE NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_HE NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_HE NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_HE NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_HE NULL
+#define OPTION_VAL_8_HE NULL
+#define OPTION_VAL_12_HE NULL
+#define OPTION_VAL_16_HE NULL
+#define OPTION_VAL_24_HE NULL
+#define OPTION_VAL_32_HE NULL
+#define OPTION_VAL_48_HE NULL
+#define OPTION_VAL_64_HE NULL
+#define OPTION_VAL_128_HE NULL
+#define OPTION_VAL_256_HE NULL
+
+struct retro_core_option_v2_category option_cats_he[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_he[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_HE,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_HE,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_HE },
+         { "640x400",   OPTION_VAL_640X400_HE },
+         { "960x600",   OPTION_VAL_960X600_HE },
+         { "1280x800",  OPTION_VAL_1280X800_HE },
+         { "1600x1000", OPTION_VAL_1600X1000_HE },
+         { "1920x1200", OPTION_VAL_1920X1200_HE },
+         { "2240x1400", OPTION_VAL_2240X1400_HE },
+         { "2560x1600", OPTION_VAL_2560X1600_HE },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_HE,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_HE,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_HE,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_HE,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_HE,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_HE,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_HE,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_HE,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_HE,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_HE,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_HE },
+         { "12",  OPTION_VAL_12_HE },
+         { "16",  OPTION_VAL_16_HE },
+         { "24",  OPTION_VAL_24_HE },
+         { "32",  OPTION_VAL_32_HE },
+         { "48",  OPTION_VAL_48_HE },
+         { "64",  OPTION_VAL_64_HE },
+         { "128", OPTION_VAL_128_HE },
+         { "256", OPTION_VAL_256_HE },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_he = {
+   option_cats_he,
+   option_defs_he
+};
+
+/* RETRO_LANGUAGE_HU */
+
+#define PRBOOM_RESOLUTION_LABEL_HU NULL
+#define PRBOOM_RESOLUTION_INFO_0_HU NULL
+#define OPTION_VAL_320X200_HU NULL
+#define OPTION_VAL_640X400_HU NULL
+#define OPTION_VAL_960X600_HU NULL
+#define OPTION_VAL_1280X800_HU NULL
+#define OPTION_VAL_1600X1000_HU NULL
+#define OPTION_VAL_1920X1200_HU NULL
+#define OPTION_VAL_2240X1400_HU NULL
+#define OPTION_VAL_2560X1600_HU NULL
+#define PRBOOM_MOUSE_ON_LABEL_HU NULL
+#define PRBOOM_MOUSE_ON_INFO_0_HU NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_HU NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_HU NULL
+#define PRBOOM_RUMBLE_LABEL_HU NULL
+#define PRBOOM_RUMBLE_INFO_0_HU NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_HU NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_HU NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_HU NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_HU NULL
+#define OPTION_VAL_8_HU NULL
+#define OPTION_VAL_12_HU NULL
+#define OPTION_VAL_16_HU NULL
+#define OPTION_VAL_24_HU NULL
+#define OPTION_VAL_32_HU NULL
+#define OPTION_VAL_48_HU NULL
+#define OPTION_VAL_64_HU NULL
+#define OPTION_VAL_128_HU NULL
+#define OPTION_VAL_256_HU NULL
+
+struct retro_core_option_v2_category option_cats_hu[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_hu[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_HU,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_HU,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_HU },
+         { "640x400",   OPTION_VAL_640X400_HU },
+         { "960x600",   OPTION_VAL_960X600_HU },
+         { "1280x800",  OPTION_VAL_1280X800_HU },
+         { "1600x1000", OPTION_VAL_1600X1000_HU },
+         { "1920x1200", OPTION_VAL_1920X1200_HU },
+         { "2240x1400", OPTION_VAL_2240X1400_HU },
+         { "2560x1600", OPTION_VAL_2560X1600_HU },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_HU,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_HU,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_HU,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_HU,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_HU,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_HU,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_HU,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_HU,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_HU,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_HU,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_HU },
+         { "12",  OPTION_VAL_12_HU },
+         { "16",  OPTION_VAL_16_HU },
+         { "24",  OPTION_VAL_24_HU },
+         { "32",  OPTION_VAL_32_HU },
+         { "48",  OPTION_VAL_48_HU },
+         { "64",  OPTION_VAL_64_HU },
+         { "128", OPTION_VAL_128_HU },
+         { "256", OPTION_VAL_256_HU },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_hu = {
+   option_cats_hu,
+   option_defs_hu
+};
+
+/* RETRO_LANGUAGE_ID */
+
+#define PRBOOM_RESOLUTION_LABEL_ID NULL
+#define PRBOOM_RESOLUTION_INFO_0_ID NULL
+#define OPTION_VAL_320X200_ID NULL
+#define OPTION_VAL_640X400_ID NULL
+#define OPTION_VAL_960X600_ID NULL
+#define OPTION_VAL_1280X800_ID NULL
+#define OPTION_VAL_1600X1000_ID NULL
+#define OPTION_VAL_1920X1200_ID NULL
+#define OPTION_VAL_2240X1400_ID NULL
+#define OPTION_VAL_2560X1600_ID NULL
+#define PRBOOM_MOUSE_ON_LABEL_ID NULL
+#define PRBOOM_MOUSE_ON_INFO_0_ID NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_ID NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_ID NULL
+#define PRBOOM_RUMBLE_LABEL_ID NULL
+#define PRBOOM_RUMBLE_INFO_0_ID NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_ID NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_ID NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_ID NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_ID NULL
+#define OPTION_VAL_8_ID NULL
+#define OPTION_VAL_12_ID NULL
+#define OPTION_VAL_16_ID NULL
+#define OPTION_VAL_24_ID NULL
+#define OPTION_VAL_32_ID NULL
+#define OPTION_VAL_48_ID NULL
+#define OPTION_VAL_64_ID NULL
+#define OPTION_VAL_128_ID NULL
+#define OPTION_VAL_256_ID NULL
+
+struct retro_core_option_v2_category option_cats_id[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_id[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_ID,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_ID,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_ID },
+         { "640x400",   OPTION_VAL_640X400_ID },
+         { "960x600",   OPTION_VAL_960X600_ID },
+         { "1280x800",  OPTION_VAL_1280X800_ID },
+         { "1600x1000", OPTION_VAL_1600X1000_ID },
+         { "1920x1200", OPTION_VAL_1920X1200_ID },
+         { "2240x1400", OPTION_VAL_2240X1400_ID },
+         { "2560x1600", OPTION_VAL_2560X1600_ID },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_ID,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_ID,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_ID,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_ID,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_ID,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_ID,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_ID,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_ID,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_ID,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_ID,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_ID },
+         { "12",  OPTION_VAL_12_ID },
+         { "16",  OPTION_VAL_16_ID },
+         { "24",  OPTION_VAL_24_ID },
+         { "32",  OPTION_VAL_32_ID },
+         { "48",  OPTION_VAL_48_ID },
+         { "64",  OPTION_VAL_64_ID },
+         { "128", OPTION_VAL_128_ID },
+         { "256", OPTION_VAL_256_ID },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_id = {
+   option_cats_id,
+   option_defs_id
+};
+
+/* RETRO_LANGUAGE_IT */
+
+#define PRBOOM_RESOLUTION_LABEL_IT NULL
+#define PRBOOM_RESOLUTION_INFO_0_IT NULL
+#define OPTION_VAL_320X200_IT NULL
+#define OPTION_VAL_640X400_IT NULL
+#define OPTION_VAL_960X600_IT NULL
+#define OPTION_VAL_1280X800_IT NULL
+#define OPTION_VAL_1600X1000_IT NULL
+#define OPTION_VAL_1920X1200_IT NULL
+#define OPTION_VAL_2240X1400_IT NULL
+#define OPTION_VAL_2560X1600_IT NULL
+#define PRBOOM_MOUSE_ON_LABEL_IT NULL
+#define PRBOOM_MOUSE_ON_INFO_0_IT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_IT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_IT NULL
+#define PRBOOM_RUMBLE_LABEL_IT NULL
+#define PRBOOM_RUMBLE_INFO_0_IT NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_IT NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_IT NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_IT NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_IT NULL
+#define OPTION_VAL_8_IT NULL
+#define OPTION_VAL_12_IT NULL
+#define OPTION_VAL_16_IT NULL
+#define OPTION_VAL_24_IT NULL
+#define OPTION_VAL_32_IT NULL
+#define OPTION_VAL_48_IT NULL
+#define OPTION_VAL_64_IT NULL
+#define OPTION_VAL_128_IT NULL
+#define OPTION_VAL_256_IT NULL
+
+struct retro_core_option_v2_category option_cats_it[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_it[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_IT,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_IT,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_IT },
+         { "640x400",   OPTION_VAL_640X400_IT },
+         { "960x600",   OPTION_VAL_960X600_IT },
+         { "1280x800",  OPTION_VAL_1280X800_IT },
+         { "1600x1000", OPTION_VAL_1600X1000_IT },
+         { "1920x1200", OPTION_VAL_1920X1200_IT },
+         { "2240x1400", OPTION_VAL_2240X1400_IT },
+         { "2560x1600", OPTION_VAL_2560X1600_IT },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_IT,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_IT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_IT,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_IT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_IT,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_IT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_IT,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_IT,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_IT,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_IT,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_IT },
+         { "12",  OPTION_VAL_12_IT },
+         { "16",  OPTION_VAL_16_IT },
+         { "24",  OPTION_VAL_24_IT },
+         { "32",  OPTION_VAL_32_IT },
+         { "48",  OPTION_VAL_48_IT },
+         { "64",  OPTION_VAL_64_IT },
+         { "128", OPTION_VAL_128_IT },
+         { "256", OPTION_VAL_256_IT },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_it = {
+   option_cats_it,
+   option_defs_it
+};
+
+/* RETRO_LANGUAGE_JA */
+
+#define PRBOOM_RESOLUTION_LABEL_JA NULL
+#define PRBOOM_RESOLUTION_INFO_0_JA NULL
+#define OPTION_VAL_320X200_JA NULL
+#define OPTION_VAL_640X400_JA NULL
+#define OPTION_VAL_960X600_JA NULL
+#define OPTION_VAL_1280X800_JA NULL
+#define OPTION_VAL_1600X1000_JA NULL
+#define OPTION_VAL_1920X1200_JA NULL
+#define OPTION_VAL_2240X1400_JA NULL
+#define OPTION_VAL_2560X1600_JA NULL
+#define PRBOOM_MOUSE_ON_LABEL_JA NULL
+#define PRBOOM_MOUSE_ON_INFO_0_JA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_JA NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_JA NULL
+#define PRBOOM_RUMBLE_LABEL_JA NULL
+#define PRBOOM_RUMBLE_INFO_0_JA NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_JA NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_JA NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_JA NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_JA NULL
+#define OPTION_VAL_8_JA NULL
+#define OPTION_VAL_12_JA NULL
+#define OPTION_VAL_16_JA NULL
+#define OPTION_VAL_24_JA NULL
+#define OPTION_VAL_32_JA NULL
+#define OPTION_VAL_48_JA NULL
+#define OPTION_VAL_64_JA NULL
+#define OPTION_VAL_128_JA NULL
+#define OPTION_VAL_256_JA NULL
+
+struct retro_core_option_v2_category option_cats_ja[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ja[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_JA,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_JA,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_JA },
+         { "640x400",   OPTION_VAL_640X400_JA },
+         { "960x600",   OPTION_VAL_960X600_JA },
+         { "1280x800",  OPTION_VAL_1280X800_JA },
+         { "1600x1000", OPTION_VAL_1600X1000_JA },
+         { "1920x1200", OPTION_VAL_1920X1200_JA },
+         { "2240x1400", OPTION_VAL_2240X1400_JA },
+         { "2560x1600", OPTION_VAL_2560X1600_JA },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_JA,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_JA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_JA,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_JA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_JA,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_JA,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_JA,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_JA,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_JA,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_JA,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_JA },
+         { "12",  OPTION_VAL_12_JA },
+         { "16",  OPTION_VAL_16_JA },
+         { "24",  OPTION_VAL_24_JA },
+         { "32",  OPTION_VAL_32_JA },
+         { "48",  OPTION_VAL_48_JA },
+         { "64",  OPTION_VAL_64_JA },
+         { "128", OPTION_VAL_128_JA },
+         { "256", OPTION_VAL_256_JA },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ja = {
+   option_cats_ja,
+   option_defs_ja
+};
+
+/* RETRO_LANGUAGE_KO */
+
+#define PRBOOM_RESOLUTION_LABEL_KO NULL
+#define PRBOOM_RESOLUTION_INFO_0_KO NULL
+#define OPTION_VAL_320X200_KO NULL
+#define OPTION_VAL_640X400_KO NULL
+#define OPTION_VAL_960X600_KO NULL
+#define OPTION_VAL_1280X800_KO NULL
+#define OPTION_VAL_1600X1000_KO NULL
+#define OPTION_VAL_1920X1200_KO NULL
+#define OPTION_VAL_2240X1400_KO NULL
+#define OPTION_VAL_2560X1600_KO NULL
+#define PRBOOM_MOUSE_ON_LABEL_KO NULL
+#define PRBOOM_MOUSE_ON_INFO_0_KO NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_KO NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_KO NULL
+#define PRBOOM_RUMBLE_LABEL_KO NULL
+#define PRBOOM_RUMBLE_INFO_0_KO NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_KO NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_KO NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_KO NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_KO NULL
+#define OPTION_VAL_8_KO NULL
+#define OPTION_VAL_12_KO NULL
+#define OPTION_VAL_16_KO NULL
+#define OPTION_VAL_24_KO NULL
+#define OPTION_VAL_32_KO NULL
+#define OPTION_VAL_48_KO NULL
+#define OPTION_VAL_64_KO NULL
+#define OPTION_VAL_128_KO NULL
+#define OPTION_VAL_256_KO NULL
+
+struct retro_core_option_v2_category option_cats_ko[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ko[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_KO,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_KO,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_KO },
+         { "640x400",   OPTION_VAL_640X400_KO },
+         { "960x600",   OPTION_VAL_960X600_KO },
+         { "1280x800",  OPTION_VAL_1280X800_KO },
+         { "1600x1000", OPTION_VAL_1600X1000_KO },
+         { "1920x1200", OPTION_VAL_1920X1200_KO },
+         { "2240x1400", OPTION_VAL_2240X1400_KO },
+         { "2560x1600", OPTION_VAL_2560X1600_KO },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_KO,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_KO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_KO,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_KO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_KO,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_KO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_KO,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_KO,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_KO,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_KO,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_KO },
+         { "12",  OPTION_VAL_12_KO },
+         { "16",  OPTION_VAL_16_KO },
+         { "24",  OPTION_VAL_24_KO },
+         { "32",  OPTION_VAL_32_KO },
+         { "48",  OPTION_VAL_48_KO },
+         { "64",  OPTION_VAL_64_KO },
+         { "128", OPTION_VAL_128_KO },
+         { "256", OPTION_VAL_256_KO },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ko = {
+   option_cats_ko,
+   option_defs_ko
+};
+
+/* RETRO_LANGUAGE_MT */
+
+#define PRBOOM_RESOLUTION_LABEL_MT NULL
+#define PRBOOM_RESOLUTION_INFO_0_MT NULL
+#define OPTION_VAL_320X200_MT NULL
+#define OPTION_VAL_640X400_MT NULL
+#define OPTION_VAL_960X600_MT NULL
+#define OPTION_VAL_1280X800_MT NULL
+#define OPTION_VAL_1600X1000_MT NULL
+#define OPTION_VAL_1920X1200_MT NULL
+#define OPTION_VAL_2240X1400_MT NULL
+#define OPTION_VAL_2560X1600_MT NULL
+#define PRBOOM_MOUSE_ON_LABEL_MT NULL
+#define PRBOOM_MOUSE_ON_INFO_0_MT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_MT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_MT NULL
+#define PRBOOM_RUMBLE_LABEL_MT NULL
+#define PRBOOM_RUMBLE_INFO_0_MT NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_MT NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_MT NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_MT NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_MT NULL
+#define OPTION_VAL_8_MT NULL
+#define OPTION_VAL_12_MT NULL
+#define OPTION_VAL_16_MT NULL
+#define OPTION_VAL_24_MT NULL
+#define OPTION_VAL_32_MT NULL
+#define OPTION_VAL_48_MT NULL
+#define OPTION_VAL_64_MT NULL
+#define OPTION_VAL_128_MT NULL
+#define OPTION_VAL_256_MT NULL
+
+struct retro_core_option_v2_category option_cats_mt[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_mt[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_MT,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_MT,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_MT },
+         { "640x400",   OPTION_VAL_640X400_MT },
+         { "960x600",   OPTION_VAL_960X600_MT },
+         { "1280x800",  OPTION_VAL_1280X800_MT },
+         { "1600x1000", OPTION_VAL_1600X1000_MT },
+         { "1920x1200", OPTION_VAL_1920X1200_MT },
+         { "2240x1400", OPTION_VAL_2240X1400_MT },
+         { "2560x1600", OPTION_VAL_2560X1600_MT },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_MT,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_MT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_MT,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_MT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_MT,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_MT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_MT,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_MT,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_MT,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_MT,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_MT },
+         { "12",  OPTION_VAL_12_MT },
+         { "16",  OPTION_VAL_16_MT },
+         { "24",  OPTION_VAL_24_MT },
+         { "32",  OPTION_VAL_32_MT },
+         { "48",  OPTION_VAL_48_MT },
+         { "64",  OPTION_VAL_64_MT },
+         { "128", OPTION_VAL_128_MT },
+         { "256", OPTION_VAL_256_MT },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_mt = {
+   option_cats_mt,
+   option_defs_mt
+};
+
+/* RETRO_LANGUAGE_NL */
+
+#define PRBOOM_RESOLUTION_LABEL_NL NULL
+#define PRBOOM_RESOLUTION_INFO_0_NL NULL
+#define OPTION_VAL_320X200_NL NULL
+#define OPTION_VAL_640X400_NL NULL
+#define OPTION_VAL_960X600_NL NULL
+#define OPTION_VAL_1280X800_NL NULL
+#define OPTION_VAL_1600X1000_NL NULL
+#define OPTION_VAL_1920X1200_NL NULL
+#define OPTION_VAL_2240X1400_NL NULL
+#define OPTION_VAL_2560X1600_NL NULL
+#define PRBOOM_MOUSE_ON_LABEL_NL NULL
+#define PRBOOM_MOUSE_ON_INFO_0_NL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_NL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_NL NULL
+#define PRBOOM_RUMBLE_LABEL_NL NULL
+#define PRBOOM_RUMBLE_INFO_0_NL NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_NL NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_NL NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_NL NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_NL NULL
+#define OPTION_VAL_8_NL NULL
+#define OPTION_VAL_12_NL NULL
+#define OPTION_VAL_16_NL NULL
+#define OPTION_VAL_24_NL NULL
+#define OPTION_VAL_32_NL NULL
+#define OPTION_VAL_48_NL NULL
+#define OPTION_VAL_64_NL NULL
+#define OPTION_VAL_128_NL NULL
+#define OPTION_VAL_256_NL NULL
+
+struct retro_core_option_v2_category option_cats_nl[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_nl[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_NL,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_NL,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_NL },
+         { "640x400",   OPTION_VAL_640X400_NL },
+         { "960x600",   OPTION_VAL_960X600_NL },
+         { "1280x800",  OPTION_VAL_1280X800_NL },
+         { "1600x1000", OPTION_VAL_1600X1000_NL },
+         { "1920x1200", OPTION_VAL_1920X1200_NL },
+         { "2240x1400", OPTION_VAL_2240X1400_NL },
+         { "2560x1600", OPTION_VAL_2560X1600_NL },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_NL,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_NL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_NL,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_NL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_NL,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_NL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_NL,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_NL,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_NL,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_NL,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_NL },
+         { "12",  OPTION_VAL_12_NL },
+         { "16",  OPTION_VAL_16_NL },
+         { "24",  OPTION_VAL_24_NL },
+         { "32",  OPTION_VAL_32_NL },
+         { "48",  OPTION_VAL_48_NL },
+         { "64",  OPTION_VAL_64_NL },
+         { "128", OPTION_VAL_128_NL },
+         { "256", OPTION_VAL_256_NL },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_nl = {
+   option_cats_nl,
+   option_defs_nl
+};
+
+/* RETRO_LANGUAGE_OC */
+
+#define PRBOOM_RESOLUTION_LABEL_OC NULL
+#define PRBOOM_RESOLUTION_INFO_0_OC NULL
+#define OPTION_VAL_320X200_OC NULL
+#define OPTION_VAL_640X400_OC NULL
+#define OPTION_VAL_960X600_OC NULL
+#define OPTION_VAL_1280X800_OC NULL
+#define OPTION_VAL_1600X1000_OC NULL
+#define OPTION_VAL_1920X1200_OC NULL
+#define OPTION_VAL_2240X1400_OC NULL
+#define OPTION_VAL_2560X1600_OC NULL
+#define PRBOOM_MOUSE_ON_LABEL_OC NULL
+#define PRBOOM_MOUSE_ON_INFO_0_OC NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_OC NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_OC NULL
+#define PRBOOM_RUMBLE_LABEL_OC NULL
+#define PRBOOM_RUMBLE_INFO_0_OC NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_OC NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_OC NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_OC NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_OC NULL
+#define OPTION_VAL_8_OC NULL
+#define OPTION_VAL_12_OC NULL
+#define OPTION_VAL_16_OC NULL
+#define OPTION_VAL_24_OC NULL
+#define OPTION_VAL_32_OC NULL
+#define OPTION_VAL_48_OC NULL
+#define OPTION_VAL_64_OC NULL
+#define OPTION_VAL_128_OC NULL
+#define OPTION_VAL_256_OC NULL
+
+struct retro_core_option_v2_category option_cats_oc[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_oc[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_OC,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_OC,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_OC },
+         { "640x400",   OPTION_VAL_640X400_OC },
+         { "960x600",   OPTION_VAL_960X600_OC },
+         { "1280x800",  OPTION_VAL_1280X800_OC },
+         { "1600x1000", OPTION_VAL_1600X1000_OC },
+         { "1920x1200", OPTION_VAL_1920X1200_OC },
+         { "2240x1400", OPTION_VAL_2240X1400_OC },
+         { "2560x1600", OPTION_VAL_2560X1600_OC },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_OC,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_OC,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_OC,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_OC,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_OC,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_OC,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_OC,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_OC,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_OC,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_OC,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_OC },
+         { "12",  OPTION_VAL_12_OC },
+         { "16",  OPTION_VAL_16_OC },
+         { "24",  OPTION_VAL_24_OC },
+         { "32",  OPTION_VAL_32_OC },
+         { "48",  OPTION_VAL_48_OC },
+         { "64",  OPTION_VAL_64_OC },
+         { "128", OPTION_VAL_128_OC },
+         { "256", OPTION_VAL_256_OC },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_oc = {
+   option_cats_oc,
+   option_defs_oc
+};
+
+/* RETRO_LANGUAGE_PL */
+
+#define PRBOOM_RESOLUTION_LABEL_PL NULL
+#define PRBOOM_RESOLUTION_INFO_0_PL NULL
+#define OPTION_VAL_320X200_PL NULL
+#define OPTION_VAL_640X400_PL NULL
+#define OPTION_VAL_960X600_PL NULL
+#define OPTION_VAL_1280X800_PL NULL
+#define OPTION_VAL_1600X1000_PL NULL
+#define OPTION_VAL_1920X1200_PL NULL
+#define OPTION_VAL_2240X1400_PL NULL
+#define OPTION_VAL_2560X1600_PL NULL
+#define PRBOOM_MOUSE_ON_LABEL_PL NULL
+#define PRBOOM_MOUSE_ON_INFO_0_PL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_PL NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_PL NULL
+#define PRBOOM_RUMBLE_LABEL_PL NULL
+#define PRBOOM_RUMBLE_INFO_0_PL NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_PL NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_PL NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_PL NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_PL NULL
+#define OPTION_VAL_8_PL NULL
+#define OPTION_VAL_12_PL NULL
+#define OPTION_VAL_16_PL NULL
+#define OPTION_VAL_24_PL NULL
+#define OPTION_VAL_32_PL NULL
+#define OPTION_VAL_48_PL NULL
+#define OPTION_VAL_64_PL NULL
+#define OPTION_VAL_128_PL NULL
+#define OPTION_VAL_256_PL NULL
+
+struct retro_core_option_v2_category option_cats_pl[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_pl[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_PL,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_PL,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_PL },
+         { "640x400",   OPTION_VAL_640X400_PL },
+         { "960x600",   OPTION_VAL_960X600_PL },
+         { "1280x800",  OPTION_VAL_1280X800_PL },
+         { "1600x1000", OPTION_VAL_1600X1000_PL },
+         { "1920x1200", OPTION_VAL_1920X1200_PL },
+         { "2240x1400", OPTION_VAL_2240X1400_PL },
+         { "2560x1600", OPTION_VAL_2560X1600_PL },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_PL,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_PL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_PL,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_PL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_PL,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_PL,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_PL,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_PL,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_PL,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_PL,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_PL },
+         { "12",  OPTION_VAL_12_PL },
+         { "16",  OPTION_VAL_16_PL },
+         { "24",  OPTION_VAL_24_PL },
+         { "32",  OPTION_VAL_32_PL },
+         { "48",  OPTION_VAL_48_PL },
+         { "64",  OPTION_VAL_64_PL },
+         { "128", OPTION_VAL_128_PL },
+         { "256", OPTION_VAL_256_PL },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_pl = {
+   option_cats_pl,
+   option_defs_pl
+};
+
+/* RETRO_LANGUAGE_PT_BR */
+
+#define PRBOOM_RESOLUTION_LABEL_PT_BR NULL
+#define PRBOOM_RESOLUTION_INFO_0_PT_BR NULL
+#define OPTION_VAL_320X200_PT_BR NULL
+#define OPTION_VAL_640X400_PT_BR NULL
+#define OPTION_VAL_960X600_PT_BR NULL
+#define OPTION_VAL_1280X800_PT_BR NULL
+#define OPTION_VAL_1600X1000_PT_BR NULL
+#define OPTION_VAL_1920X1200_PT_BR NULL
+#define OPTION_VAL_2240X1400_PT_BR NULL
+#define OPTION_VAL_2560X1600_PT_BR NULL
+#define PRBOOM_MOUSE_ON_LABEL_PT_BR NULL
+#define PRBOOM_MOUSE_ON_INFO_0_PT_BR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_PT_BR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_PT_BR NULL
+#define PRBOOM_RUMBLE_LABEL_PT_BR NULL
+#define PRBOOM_RUMBLE_INFO_0_PT_BR NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_PT_BR NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_PT_BR NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_PT_BR NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_PT_BR NULL
+#define OPTION_VAL_8_PT_BR NULL
+#define OPTION_VAL_12_PT_BR NULL
+#define OPTION_VAL_16_PT_BR NULL
+#define OPTION_VAL_24_PT_BR NULL
+#define OPTION_VAL_32_PT_BR NULL
+#define OPTION_VAL_48_PT_BR NULL
+#define OPTION_VAL_64_PT_BR NULL
+#define OPTION_VAL_128_PT_BR NULL
+#define OPTION_VAL_256_PT_BR NULL
+
+struct retro_core_option_v2_category option_cats_pt_br[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_pt_br[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_PT_BR,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_PT_BR,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_PT_BR },
+         { "640x400",   OPTION_VAL_640X400_PT_BR },
+         { "960x600",   OPTION_VAL_960X600_PT_BR },
+         { "1280x800",  OPTION_VAL_1280X800_PT_BR },
+         { "1600x1000", OPTION_VAL_1600X1000_PT_BR },
+         { "1920x1200", OPTION_VAL_1920X1200_PT_BR },
+         { "2240x1400", OPTION_VAL_2240X1400_PT_BR },
+         { "2560x1600", OPTION_VAL_2560X1600_PT_BR },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_PT_BR,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_PT_BR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_PT_BR,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_PT_BR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_PT_BR,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_PT_BR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_PT_BR,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_PT_BR,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_PT_BR,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_PT_BR,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_PT_BR },
+         { "12",  OPTION_VAL_12_PT_BR },
+         { "16",  OPTION_VAL_16_PT_BR },
+         { "24",  OPTION_VAL_24_PT_BR },
+         { "32",  OPTION_VAL_32_PT_BR },
+         { "48",  OPTION_VAL_48_PT_BR },
+         { "64",  OPTION_VAL_64_PT_BR },
+         { "128", OPTION_VAL_128_PT_BR },
+         { "256", OPTION_VAL_256_PT_BR },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_pt_br = {
+   option_cats_pt_br,
+   option_defs_pt_br
+};
+
+/* RETRO_LANGUAGE_PT_PT */
+
+#define PRBOOM_RESOLUTION_LABEL_PT_PT NULL
+#define PRBOOM_RESOLUTION_INFO_0_PT_PT NULL
+#define OPTION_VAL_320X200_PT_PT NULL
+#define OPTION_VAL_640X400_PT_PT NULL
+#define OPTION_VAL_960X600_PT_PT NULL
+#define OPTION_VAL_1280X800_PT_PT NULL
+#define OPTION_VAL_1600X1000_PT_PT NULL
+#define OPTION_VAL_1920X1200_PT_PT NULL
+#define OPTION_VAL_2240X1400_PT_PT NULL
+#define OPTION_VAL_2560X1600_PT_PT NULL
+#define PRBOOM_MOUSE_ON_LABEL_PT_PT NULL
+#define PRBOOM_MOUSE_ON_INFO_0_PT_PT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_PT_PT NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_PT_PT NULL
+#define PRBOOM_RUMBLE_LABEL_PT_PT NULL
+#define PRBOOM_RUMBLE_INFO_0_PT_PT NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_PT_PT NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_PT_PT NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_PT_PT NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_PT_PT NULL
+#define OPTION_VAL_8_PT_PT NULL
+#define OPTION_VAL_12_PT_PT NULL
+#define OPTION_VAL_16_PT_PT NULL
+#define OPTION_VAL_24_PT_PT NULL
+#define OPTION_VAL_32_PT_PT NULL
+#define OPTION_VAL_48_PT_PT NULL
+#define OPTION_VAL_64_PT_PT NULL
+#define OPTION_VAL_128_PT_PT NULL
+#define OPTION_VAL_256_PT_PT NULL
+
+struct retro_core_option_v2_category option_cats_pt_pt[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_pt_pt[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_PT_PT,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_PT_PT,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_PT_PT },
+         { "640x400",   OPTION_VAL_640X400_PT_PT },
+         { "960x600",   OPTION_VAL_960X600_PT_PT },
+         { "1280x800",  OPTION_VAL_1280X800_PT_PT },
+         { "1600x1000", OPTION_VAL_1600X1000_PT_PT },
+         { "1920x1200", OPTION_VAL_1920X1200_PT_PT },
+         { "2240x1400", OPTION_VAL_2240X1400_PT_PT },
+         { "2560x1600", OPTION_VAL_2560X1600_PT_PT },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_PT_PT,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_PT_PT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_PT_PT,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_PT_PT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_PT_PT,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_PT_PT,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_PT_PT,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_PT_PT,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_PT_PT,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_PT_PT,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_PT_PT },
+         { "12",  OPTION_VAL_12_PT_PT },
+         { "16",  OPTION_VAL_16_PT_PT },
+         { "24",  OPTION_VAL_24_PT_PT },
+         { "32",  OPTION_VAL_32_PT_PT },
+         { "48",  OPTION_VAL_48_PT_PT },
+         { "64",  OPTION_VAL_64_PT_PT },
+         { "128", OPTION_VAL_128_PT_PT },
+         { "256", OPTION_VAL_256_PT_PT },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_pt_pt = {
+   option_cats_pt_pt,
+   option_defs_pt_pt
+};
+
+/* RETRO_LANGUAGE_RO */
+
+#define PRBOOM_RESOLUTION_LABEL_RO NULL
+#define PRBOOM_RESOLUTION_INFO_0_RO NULL
+#define OPTION_VAL_320X200_RO NULL
+#define OPTION_VAL_640X400_RO NULL
+#define OPTION_VAL_960X600_RO NULL
+#define OPTION_VAL_1280X800_RO NULL
+#define OPTION_VAL_1600X1000_RO NULL
+#define OPTION_VAL_1920X1200_RO NULL
+#define OPTION_VAL_2240X1400_RO NULL
+#define OPTION_VAL_2560X1600_RO NULL
+#define PRBOOM_MOUSE_ON_LABEL_RO NULL
+#define PRBOOM_MOUSE_ON_INFO_0_RO NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_RO NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_RO NULL
+#define PRBOOM_RUMBLE_LABEL_RO NULL
+#define PRBOOM_RUMBLE_INFO_0_RO NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_RO NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_RO NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_RO NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_RO NULL
+#define OPTION_VAL_8_RO NULL
+#define OPTION_VAL_12_RO NULL
+#define OPTION_VAL_16_RO NULL
+#define OPTION_VAL_24_RO NULL
+#define OPTION_VAL_32_RO NULL
+#define OPTION_VAL_48_RO NULL
+#define OPTION_VAL_64_RO NULL
+#define OPTION_VAL_128_RO NULL
+#define OPTION_VAL_256_RO NULL
+
+struct retro_core_option_v2_category option_cats_ro[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ro[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_RO,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_RO,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_RO },
+         { "640x400",   OPTION_VAL_640X400_RO },
+         { "960x600",   OPTION_VAL_960X600_RO },
+         { "1280x800",  OPTION_VAL_1280X800_RO },
+         { "1600x1000", OPTION_VAL_1600X1000_RO },
+         { "1920x1200", OPTION_VAL_1920X1200_RO },
+         { "2240x1400", OPTION_VAL_2240X1400_RO },
+         { "2560x1600", OPTION_VAL_2560X1600_RO },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_RO,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_RO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_RO,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_RO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_RO,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_RO,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_RO,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_RO,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_RO,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_RO,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_RO },
+         { "12",  OPTION_VAL_12_RO },
+         { "16",  OPTION_VAL_16_RO },
+         { "24",  OPTION_VAL_24_RO },
+         { "32",  OPTION_VAL_32_RO },
+         { "48",  OPTION_VAL_48_RO },
+         { "64",  OPTION_VAL_64_RO },
+         { "128", OPTION_VAL_128_RO },
+         { "256", OPTION_VAL_256_RO },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ro = {
+   option_cats_ro,
+   option_defs_ro
+};
+
+/* RETRO_LANGUAGE_RU */
+
+#define PRBOOM_RESOLUTION_LABEL_RU "Внутреннее разрешение (требуется перезапуск)"
+#define PRBOOM_RESOLUTION_INFO_0_RU NULL
+#define OPTION_VAL_320X200_RU NULL
+#define OPTION_VAL_640X400_RU NULL
+#define OPTION_VAL_960X600_RU NULL
+#define OPTION_VAL_1280X800_RU NULL
+#define OPTION_VAL_1600X1000_RU NULL
+#define OPTION_VAL_1920X1200_RU NULL
+#define OPTION_VAL_2240X1400_RU NULL
+#define OPTION_VAL_2560X1600_RU NULL
+#define PRBOOM_MOUSE_ON_LABEL_RU NULL
+#define PRBOOM_MOUSE_ON_INFO_0_RU NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_RU NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_RU NULL
+#define PRBOOM_RUMBLE_LABEL_RU NULL
+#define PRBOOM_RUMBLE_INFO_0_RU NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_RU NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_RU NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_RU NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_RU NULL
+#define OPTION_VAL_8_RU NULL
+#define OPTION_VAL_12_RU NULL
+#define OPTION_VAL_16_RU NULL
+#define OPTION_VAL_24_RU NULL
+#define OPTION_VAL_32_RU NULL
+#define OPTION_VAL_48_RU NULL
+#define OPTION_VAL_64_RU NULL
+#define OPTION_VAL_128_RU NULL
+#define OPTION_VAL_256_RU NULL
+
+struct retro_core_option_v2_category option_cats_ru[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_ru[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_RU,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_RU,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_RU },
+         { "640x400",   OPTION_VAL_640X400_RU },
+         { "960x600",   OPTION_VAL_960X600_RU },
+         { "1280x800",  OPTION_VAL_1280X800_RU },
+         { "1600x1000", OPTION_VAL_1600X1000_RU },
+         { "1920x1200", OPTION_VAL_1920X1200_RU },
+         { "2240x1400", OPTION_VAL_2240X1400_RU },
+         { "2560x1600", OPTION_VAL_2560X1600_RU },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_RU,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_RU,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_RU,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_RU,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_RU,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_RU,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_RU,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_RU,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_RU,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_RU,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_RU },
+         { "12",  OPTION_VAL_12_RU },
+         { "16",  OPTION_VAL_16_RU },
+         { "24",  OPTION_VAL_24_RU },
+         { "32",  OPTION_VAL_32_RU },
+         { "48",  OPTION_VAL_48_RU },
+         { "64",  OPTION_VAL_64_RU },
+         { "128", OPTION_VAL_128_RU },
+         { "256", OPTION_VAL_256_RU },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_ru = {
+   option_cats_ru,
+   option_defs_ru
+};
+
+/* RETRO_LANGUAGE_SI */
+
+#define PRBOOM_RESOLUTION_LABEL_SI NULL
+#define PRBOOM_RESOLUTION_INFO_0_SI NULL
+#define OPTION_VAL_320X200_SI NULL
+#define OPTION_VAL_640X400_SI NULL
+#define OPTION_VAL_960X600_SI NULL
+#define OPTION_VAL_1280X800_SI NULL
+#define OPTION_VAL_1600X1000_SI NULL
+#define OPTION_VAL_1920X1200_SI NULL
+#define OPTION_VAL_2240X1400_SI NULL
+#define OPTION_VAL_2560X1600_SI NULL
+#define PRBOOM_MOUSE_ON_LABEL_SI NULL
+#define PRBOOM_MOUSE_ON_INFO_0_SI NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_SI NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_SI NULL
+#define PRBOOM_RUMBLE_LABEL_SI NULL
+#define PRBOOM_RUMBLE_INFO_0_SI NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_SI NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_SI NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_SI NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_SI NULL
+#define OPTION_VAL_8_SI NULL
+#define OPTION_VAL_12_SI NULL
+#define OPTION_VAL_16_SI NULL
+#define OPTION_VAL_24_SI NULL
+#define OPTION_VAL_32_SI NULL
+#define OPTION_VAL_48_SI NULL
+#define OPTION_VAL_64_SI NULL
+#define OPTION_VAL_128_SI NULL
+#define OPTION_VAL_256_SI NULL
+
+struct retro_core_option_v2_category option_cats_si[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_si[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_SI,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_SI,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_SI },
+         { "640x400",   OPTION_VAL_640X400_SI },
+         { "960x600",   OPTION_VAL_960X600_SI },
+         { "1280x800",  OPTION_VAL_1280X800_SI },
+         { "1600x1000", OPTION_VAL_1600X1000_SI },
+         { "1920x1200", OPTION_VAL_1920X1200_SI },
+         { "2240x1400", OPTION_VAL_2240X1400_SI },
+         { "2560x1600", OPTION_VAL_2560X1600_SI },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_SI,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_SI,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_SI,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_SI,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_SI,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_SI,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_SI,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_SI,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_SI,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_SI,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_SI },
+         { "12",  OPTION_VAL_12_SI },
+         { "16",  OPTION_VAL_16_SI },
+         { "24",  OPTION_VAL_24_SI },
+         { "32",  OPTION_VAL_32_SI },
+         { "48",  OPTION_VAL_48_SI },
+         { "64",  OPTION_VAL_64_SI },
+         { "128", OPTION_VAL_128_SI },
+         { "256", OPTION_VAL_256_SI },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_si = {
+   option_cats_si,
+   option_defs_si
+};
+
+/* RETRO_LANGUAGE_SK */
+
+#define PRBOOM_RESOLUTION_LABEL_SK NULL
+#define PRBOOM_RESOLUTION_INFO_0_SK NULL
+#define OPTION_VAL_320X200_SK NULL
+#define OPTION_VAL_640X400_SK NULL
+#define OPTION_VAL_960X600_SK NULL
+#define OPTION_VAL_1280X800_SK NULL
+#define OPTION_VAL_1600X1000_SK NULL
+#define OPTION_VAL_1920X1200_SK NULL
+#define OPTION_VAL_2240X1400_SK NULL
+#define OPTION_VAL_2560X1600_SK NULL
+#define PRBOOM_MOUSE_ON_LABEL_SK NULL
+#define PRBOOM_MOUSE_ON_INFO_0_SK NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_SK NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_SK NULL
+#define PRBOOM_RUMBLE_LABEL_SK NULL
+#define PRBOOM_RUMBLE_INFO_0_SK NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_SK NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_SK NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_SK NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_SK NULL
+#define OPTION_VAL_8_SK NULL
+#define OPTION_VAL_12_SK NULL
+#define OPTION_VAL_16_SK NULL
+#define OPTION_VAL_24_SK NULL
+#define OPTION_VAL_32_SK NULL
+#define OPTION_VAL_48_SK NULL
+#define OPTION_VAL_64_SK NULL
+#define OPTION_VAL_128_SK NULL
+#define OPTION_VAL_256_SK NULL
+
+struct retro_core_option_v2_category option_cats_sk[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_sk[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_SK,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_SK,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_SK },
+         { "640x400",   OPTION_VAL_640X400_SK },
+         { "960x600",   OPTION_VAL_960X600_SK },
+         { "1280x800",  OPTION_VAL_1280X800_SK },
+         { "1600x1000", OPTION_VAL_1600X1000_SK },
+         { "1920x1200", OPTION_VAL_1920X1200_SK },
+         { "2240x1400", OPTION_VAL_2240X1400_SK },
+         { "2560x1600", OPTION_VAL_2560X1600_SK },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_SK,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_SK,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_SK,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_SK,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_SK,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_SK,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_SK,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_SK,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_SK,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_SK,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_SK },
+         { "12",  OPTION_VAL_12_SK },
+         { "16",  OPTION_VAL_16_SK },
+         { "24",  OPTION_VAL_24_SK },
+         { "32",  OPTION_VAL_32_SK },
+         { "48",  OPTION_VAL_48_SK },
+         { "64",  OPTION_VAL_64_SK },
+         { "128", OPTION_VAL_128_SK },
+         { "256", OPTION_VAL_256_SK },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_sk = {
+   option_cats_sk,
+   option_defs_sk
+};
+
+/* RETRO_LANGUAGE_SR */
+
+#define PRBOOM_RESOLUTION_LABEL_SR NULL
+#define PRBOOM_RESOLUTION_INFO_0_SR NULL
+#define OPTION_VAL_320X200_SR NULL
+#define OPTION_VAL_640X400_SR NULL
+#define OPTION_VAL_960X600_SR NULL
+#define OPTION_VAL_1280X800_SR NULL
+#define OPTION_VAL_1600X1000_SR NULL
+#define OPTION_VAL_1920X1200_SR NULL
+#define OPTION_VAL_2240X1400_SR NULL
+#define OPTION_VAL_2560X1600_SR NULL
+#define PRBOOM_MOUSE_ON_LABEL_SR NULL
+#define PRBOOM_MOUSE_ON_INFO_0_SR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_SR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_SR NULL
+#define PRBOOM_RUMBLE_LABEL_SR NULL
+#define PRBOOM_RUMBLE_INFO_0_SR NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_SR NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_SR NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_SR NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_SR NULL
+#define OPTION_VAL_8_SR NULL
+#define OPTION_VAL_12_SR NULL
+#define OPTION_VAL_16_SR NULL
+#define OPTION_VAL_24_SR NULL
+#define OPTION_VAL_32_SR NULL
+#define OPTION_VAL_48_SR NULL
+#define OPTION_VAL_64_SR NULL
+#define OPTION_VAL_128_SR NULL
+#define OPTION_VAL_256_SR NULL
+
+struct retro_core_option_v2_category option_cats_sr[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_sr[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_SR,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_SR,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_SR },
+         { "640x400",   OPTION_VAL_640X400_SR },
+         { "960x600",   OPTION_VAL_960X600_SR },
+         { "1280x800",  OPTION_VAL_1280X800_SR },
+         { "1600x1000", OPTION_VAL_1600X1000_SR },
+         { "1920x1200", OPTION_VAL_1920X1200_SR },
+         { "2240x1400", OPTION_VAL_2240X1400_SR },
+         { "2560x1600", OPTION_VAL_2560X1600_SR },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_SR,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_SR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_SR,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_SR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_SR,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_SR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_SR,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_SR,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_SR,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_SR,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_SR },
+         { "12",  OPTION_VAL_12_SR },
+         { "16",  OPTION_VAL_16_SR },
+         { "24",  OPTION_VAL_24_SR },
+         { "32",  OPTION_VAL_32_SR },
+         { "48",  OPTION_VAL_48_SR },
+         { "64",  OPTION_VAL_64_SR },
+         { "128", OPTION_VAL_128_SR },
+         { "256", OPTION_VAL_256_SR },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_sr = {
+   option_cats_sr,
+   option_defs_sr
+};
+
+/* RETRO_LANGUAGE_SV */
+
+#define PRBOOM_RESOLUTION_LABEL_SV NULL
+#define PRBOOM_RESOLUTION_INFO_0_SV NULL
+#define OPTION_VAL_320X200_SV NULL
+#define OPTION_VAL_640X400_SV NULL
+#define OPTION_VAL_960X600_SV NULL
+#define OPTION_VAL_1280X800_SV NULL
+#define OPTION_VAL_1600X1000_SV NULL
+#define OPTION_VAL_1920X1200_SV NULL
+#define OPTION_VAL_2240X1400_SV NULL
+#define OPTION_VAL_2560X1600_SV NULL
+#define PRBOOM_MOUSE_ON_LABEL_SV NULL
+#define PRBOOM_MOUSE_ON_INFO_0_SV NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_SV NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_SV NULL
+#define PRBOOM_RUMBLE_LABEL_SV NULL
+#define PRBOOM_RUMBLE_INFO_0_SV NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_SV NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_SV NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_SV NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_SV NULL
+#define OPTION_VAL_8_SV NULL
+#define OPTION_VAL_12_SV NULL
+#define OPTION_VAL_16_SV NULL
+#define OPTION_VAL_24_SV NULL
+#define OPTION_VAL_32_SV NULL
+#define OPTION_VAL_48_SV NULL
+#define OPTION_VAL_64_SV NULL
+#define OPTION_VAL_128_SV NULL
+#define OPTION_VAL_256_SV NULL
+
+struct retro_core_option_v2_category option_cats_sv[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_sv[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_SV,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_SV,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_SV },
+         { "640x400",   OPTION_VAL_640X400_SV },
+         { "960x600",   OPTION_VAL_960X600_SV },
+         { "1280x800",  OPTION_VAL_1280X800_SV },
+         { "1600x1000", OPTION_VAL_1600X1000_SV },
+         { "1920x1200", OPTION_VAL_1920X1200_SV },
+         { "2240x1400", OPTION_VAL_2240X1400_SV },
+         { "2560x1600", OPTION_VAL_2560X1600_SV },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_SV,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_SV,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_SV,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_SV,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_SV,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_SV,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_SV,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_SV,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_SV,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_SV,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_SV },
+         { "12",  OPTION_VAL_12_SV },
+         { "16",  OPTION_VAL_16_SV },
+         { "24",  OPTION_VAL_24_SV },
+         { "32",  OPTION_VAL_32_SV },
+         { "48",  OPTION_VAL_48_SV },
+         { "64",  OPTION_VAL_64_SV },
+         { "128", OPTION_VAL_128_SV },
+         { "256", OPTION_VAL_256_SV },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_sv = {
+   option_cats_sv,
+   option_defs_sv
+};
+
+/* RETRO_LANGUAGE_TR */
+
+#define PRBOOM_RESOLUTION_LABEL_TR NULL
+#define PRBOOM_RESOLUTION_INFO_0_TR NULL
+#define OPTION_VAL_320X200_TR NULL
+#define OPTION_VAL_640X400_TR NULL
+#define OPTION_VAL_960X600_TR NULL
+#define OPTION_VAL_1280X800_TR NULL
+#define OPTION_VAL_1600X1000_TR NULL
+#define OPTION_VAL_1920X1200_TR NULL
+#define OPTION_VAL_2240X1400_TR NULL
+#define OPTION_VAL_2560X1600_TR NULL
+#define PRBOOM_MOUSE_ON_LABEL_TR NULL
+#define PRBOOM_MOUSE_ON_INFO_0_TR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_TR NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_TR NULL
+#define PRBOOM_RUMBLE_LABEL_TR NULL
+#define PRBOOM_RUMBLE_INFO_0_TR NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_TR NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_TR NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_TR NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_TR NULL
+#define OPTION_VAL_8_TR NULL
+#define OPTION_VAL_12_TR NULL
+#define OPTION_VAL_16_TR NULL
+#define OPTION_VAL_24_TR NULL
+#define OPTION_VAL_32_TR NULL
+#define OPTION_VAL_48_TR NULL
+#define OPTION_VAL_64_TR NULL
+#define OPTION_VAL_128_TR NULL
+#define OPTION_VAL_256_TR NULL
+
+struct retro_core_option_v2_category option_cats_tr[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_tr[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_TR,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_TR,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_TR },
+         { "640x400",   OPTION_VAL_640X400_TR },
+         { "960x600",   OPTION_VAL_960X600_TR },
+         { "1280x800",  OPTION_VAL_1280X800_TR },
+         { "1600x1000", OPTION_VAL_1600X1000_TR },
+         { "1920x1200", OPTION_VAL_1920X1200_TR },
+         { "2240x1400", OPTION_VAL_2240X1400_TR },
+         { "2560x1600", OPTION_VAL_2560X1600_TR },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_TR,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_TR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_TR,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_TR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_TR,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_TR,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_TR,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_TR,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_TR,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_TR,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_TR },
+         { "12",  OPTION_VAL_12_TR },
+         { "16",  OPTION_VAL_16_TR },
+         { "24",  OPTION_VAL_24_TR },
+         { "32",  OPTION_VAL_32_TR },
+         { "48",  OPTION_VAL_48_TR },
+         { "64",  OPTION_VAL_64_TR },
+         { "128", OPTION_VAL_128_TR },
+         { "256", OPTION_VAL_256_TR },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_tr = {
+   option_cats_tr,
+   option_defs_tr
+};
+
+/* RETRO_LANGUAGE_UK */
+
+#define PRBOOM_RESOLUTION_LABEL_UK NULL
+#define PRBOOM_RESOLUTION_INFO_0_UK NULL
+#define OPTION_VAL_320X200_UK NULL
+#define OPTION_VAL_640X400_UK NULL
+#define OPTION_VAL_960X600_UK NULL
+#define OPTION_VAL_1280X800_UK NULL
+#define OPTION_VAL_1600X1000_UK NULL
+#define OPTION_VAL_1920X1200_UK NULL
+#define OPTION_VAL_2240X1400_UK NULL
+#define OPTION_VAL_2560X1600_UK NULL
+#define PRBOOM_MOUSE_ON_LABEL_UK NULL
+#define PRBOOM_MOUSE_ON_INFO_0_UK NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_UK NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_UK NULL
+#define PRBOOM_RUMBLE_LABEL_UK NULL
+#define PRBOOM_RUMBLE_INFO_0_UK NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_UK NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_UK NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_UK NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_UK NULL
+#define OPTION_VAL_8_UK NULL
+#define OPTION_VAL_12_UK NULL
+#define OPTION_VAL_16_UK NULL
+#define OPTION_VAL_24_UK NULL
+#define OPTION_VAL_32_UK NULL
+#define OPTION_VAL_48_UK NULL
+#define OPTION_VAL_64_UK NULL
+#define OPTION_VAL_128_UK NULL
+#define OPTION_VAL_256_UK NULL
+
+struct retro_core_option_v2_category option_cats_uk[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_uk[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_UK,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_UK,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_UK },
+         { "640x400",   OPTION_VAL_640X400_UK },
+         { "960x600",   OPTION_VAL_960X600_UK },
+         { "1280x800",  OPTION_VAL_1280X800_UK },
+         { "1600x1000", OPTION_VAL_1600X1000_UK },
+         { "1920x1200", OPTION_VAL_1920X1200_UK },
+         { "2240x1400", OPTION_VAL_2240X1400_UK },
+         { "2560x1600", OPTION_VAL_2560X1600_UK },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_UK,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_UK,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_UK,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_UK,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_UK,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_UK,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_UK,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_UK,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_UK,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_UK,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_UK },
+         { "12",  OPTION_VAL_12_UK },
+         { "16",  OPTION_VAL_16_UK },
+         { "24",  OPTION_VAL_24_UK },
+         { "32",  OPTION_VAL_32_UK },
+         { "48",  OPTION_VAL_48_UK },
+         { "64",  OPTION_VAL_64_UK },
+         { "128", OPTION_VAL_128_UK },
+         { "256", OPTION_VAL_256_UK },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_uk = {
+   option_cats_uk,
+   option_defs_uk
+};
+
+/* RETRO_LANGUAGE_VN */
+
+#define PRBOOM_RESOLUTION_LABEL_VN NULL
+#define PRBOOM_RESOLUTION_INFO_0_VN NULL
+#define OPTION_VAL_320X200_VN NULL
+#define OPTION_VAL_640X400_VN NULL
+#define OPTION_VAL_960X600_VN NULL
+#define OPTION_VAL_1280X800_VN NULL
+#define OPTION_VAL_1600X1000_VN NULL
+#define OPTION_VAL_1920X1200_VN NULL
+#define OPTION_VAL_2240X1400_VN NULL
+#define OPTION_VAL_2560X1600_VN NULL
+#define PRBOOM_MOUSE_ON_LABEL_VN NULL
+#define PRBOOM_MOUSE_ON_INFO_0_VN NULL
+#define PRBOOM_FIND_RECURSIVE_ON_LABEL_VN NULL
+#define PRBOOM_FIND_RECURSIVE_ON_INFO_0_VN NULL
+#define PRBOOM_RUMBLE_LABEL_VN NULL
+#define PRBOOM_RUMBLE_INFO_0_VN NULL
+#define PRBOOM_ANALOG_DEADZONE_LABEL_VN NULL
+#define PRBOOM_ANALOG_DEADZONE_INFO_0_VN NULL
+#define PRBOOM_PURGE_LIMIT_LABEL_VN NULL
+#define PRBOOM_PURGE_LIMIT_INFO_0_VN NULL
+#define OPTION_VAL_8_VN NULL
+#define OPTION_VAL_12_VN NULL
+#define OPTION_VAL_16_VN NULL
+#define OPTION_VAL_24_VN NULL
+#define OPTION_VAL_32_VN NULL
+#define OPTION_VAL_48_VN NULL
+#define OPTION_VAL_64_VN NULL
+#define OPTION_VAL_128_VN NULL
+#define OPTION_VAL_256_VN NULL
+
+struct retro_core_option_v2_category option_cats_vn[] = {
+   { NULL, NULL, NULL },
+};
+struct retro_core_option_v2_definition option_defs_vn[] = {
+   {
+      "prboom-resolution",
+      PRBOOM_RESOLUTION_LABEL_VN,
+      NULL,
+      PRBOOM_RESOLUTION_INFO_0_VN,
+      NULL,
+      NULL,
+      {
+         { "320x200",   OPTION_VAL_320X200_VN },
+         { "640x400",   OPTION_VAL_640X400_VN },
+         { "960x600",   OPTION_VAL_960X600_VN },
+         { "1280x800",  OPTION_VAL_1280X800_VN },
+         { "1600x1000", OPTION_VAL_1600X1000_VN },
+         { "1920x1200", OPTION_VAL_1920X1200_VN },
+         { "2240x1400", OPTION_VAL_2240X1400_VN },
+         { "2560x1600", OPTION_VAL_2560X1600_VN },
+         { NULL, NULL },
+      },
+      "320x200"
+   },
+   {
+      "prboom-mouse_on",
+      PRBOOM_MOUSE_ON_LABEL_VN,
+      NULL,
+      PRBOOM_MOUSE_ON_INFO_0_VN,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-find_recursive_on",
+      PRBOOM_FIND_RECURSIVE_ON_LABEL_VN,
+      NULL,
+      PRBOOM_FIND_RECURSIVE_ON_INFO_0_VN,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "prboom-rumble",
+      PRBOOM_RUMBLE_LABEL_VN,
+      NULL,
+      PRBOOM_RUMBLE_INFO_0_VN,
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "prboom-analog_deadzone",
+      PRBOOM_ANALOG_DEADZONE_LABEL_VN,
+      NULL,
+      PRBOOM_ANALOG_DEADZONE_INFO_0_VN,
+      NULL,
+      NULL,
+      {
+         { "0",  NULL },
+         { "5",  NULL },
+         { "10", NULL },
+         { "15", NULL },
+         { "20", NULL },
+         { "25", NULL },
+         { "30", NULL },
+         { NULL, NULL },
+      },
+      "15"
+   },
+#if defined(MEMORY_LOW)
+   {
+      "prboom-purge_limit",
+      PRBOOM_PURGE_LIMIT_LABEL_VN,
+      NULL,
+      PRBOOM_PURGE_LIMIT_INFO_0_VN,
+      NULL,
+      NULL,
+      {
+         { "8",   OPTION_VAL_8_VN },
+         { "12",  OPTION_VAL_12_VN },
+         { "16",  OPTION_VAL_16_VN },
+         { "24",  OPTION_VAL_24_VN },
+         { "32",  OPTION_VAL_32_VN },
+         { "48",  OPTION_VAL_48_VN },
+         { "64",  OPTION_VAL_64_VN },
+         { "128", OPTION_VAL_128_VN },
+         { "256", OPTION_VAL_256_VN },
+         { NULL, NULL },
+      },
+      "16"
+   },
+#endif
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+struct retro_core_options_v2 options_vn = {
+   option_cats_vn,
+   option_defs_vn
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Made core options conform to libretro standards & updated to v2, although I did not use any categories.

Synchronization is confirmed working; this already includes newest translations.

@jdgleaver I thought, I'd let you know:
The `libretro_core_options.h` file now contains the usual `#ifndef HAVE_NO_LANGEXTRA` instructions, but I don't think the core used them originally. I'm also not sure how/when to define `HAVE_NO_LANGEXTRA` or whether that's even necessary/worth it here.