### PR TITLE
Fix wrong audio samplerate when using framerates other than 60FPS.

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -421,7 +421,8 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
       info->timing.fps = TICRATE;
       break;
   }
-  info->timing.sample_rate = 44100.0;
+  float rate_factor = info->timing.fps / 60.0;
+  info->timing.sample_rate = 44100.0 * rate_factor;
   info->geometry.base_width = SCREENWIDTH;
   info->geometry.base_height = SCREENHEIGHT;
   info->geometry.max_width = SCREENWIDTH;


### PR DESCRIPTION
The engine seems to generate 44100 samples per second, which sounds good at 60FPS, but sounds at the wrong speed when settings other framerates in the the game options.
So this simply compensates the number of samples generated so it sounds good with other framerates.