### PR TITLE
fix compile with gcc-14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ ifeq ($(platform), unix)
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=libretro/link.T -Wl,--no-undefined -Wl,--as-needed
    CFLAGS += -std=c99
+   CFLAGS += -D_POSIX_C_SOURCE=199309L
 else ifeq ($(platform), linux-portable)
 	EXT    ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)


### PR DESCRIPTION
- fixes #190 

ftruncate and fileno are not defined unless a minimum of _POSIX_C_SOURCE=199309L is set

fixes:
libretro/libretro-common/vfs/vfs_implementation.c: In function 'retro_vfs_file_truncate_impl': libretro/libretro-common/vfs/vfs_implementation.c:619:18: error: implicit declaration of function 'ftruncate'; did you mean 'strncat'? [-Wimplicit-function-declaration]
  619 |    if (stream && ftruncate(fileno(stream->fp), (off_t)length) == 0)
      |                  ^~~~~~~~~
      |                  strncat
libretro/libretro-common/vfs/vfs_implementation.c:619:28: error: implicit declaration of function 'fileno'; did you mean 'd_fileno'? [-Wimplicit-function-declaration]
  619 |    if (stream && ftruncate(fileno(stream->fp), (off_t)length) == 0)
      |                            ^~~~~~
      |                            d_fileno