### PR TITLE
libretro: fix compilation on wii u sdk

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -270,6 +270,9 @@ endif
 $(LIBRETRO_COMM_DIR)/rthreads/rthreads.o: override CFLAGS += -DZ_ZONE_NO_ALLOC_OVERRIDE
 $(CORE_DIR)/r_rendermt.o:                   override CFLAGS += -DZ_ZONE_NO_ALLOC_OVERRIDE
 
+$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.o: \
+	override CFLAGS += -DZ_ZONE_NO_ALLOC_OVERRIDE
+
 INCFLAGS += -include z_zone.h
 endif
 


### PR DESCRIPTION
Hopefully.

```
/opt/devkitpro/devkitPPC/bin/powerpc-eabi-gcc -DGIT_VERSION=\"" daa9b73"\" -DGEKKO -DHW_RVL -DWIIU -mcpu=750 -meabi -mhard-float -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__  -DSTATIC_LINKING -O2 -DNDEBUG -DHAVE_RVORBIS -DHAVE_RMP3 -DHAVE_RMODTRACKER -DHAVE_RWAV -DHAVE_RPNG -DHAVE_RJPEG -DINLINE="inline" -fomit-frame-pointer  -Wall -W -Wno-unused-parameter  -I. -Isrc -I./libretro/libretro-common/include -include z_zone.h  -c -olibretro/libretro-common/vfs/vfs_implementation.o libretro/libretro-common/vfs/vfs_implementation.c
In file included from <command-line>:
src/z_zone.h:96:39: error: expected declaration specifiers or '...' before 'PU_STATIC'
   96 | #define malloc(n)          Z_Malloc(n,PU_STATIC,0)
      |                                       ^~~~~~~~~
src/z_zone.h:96:49: error: expected declaration specifiers or '...' before numeric constant
   96 | #define malloc(n)          Z_Malloc(n,PU_STATIC,0)
      |                                                 ^
src/z_zone.h:98:42: error: expected declaration specifiers or '...' before 'PU_STATIC'
   98 | #define realloc(p,n)       Z_Realloc(p,n,PU_STATIC,0)
      |                                          ^~~~~~~~~
src/z_zone.h:98:52: error: expected declaration specifiers or '...' before numeric constant
   98 | #define realloc(p,n)       Z_Realloc(p,n,PU_STATIC,0)
      |                                                    ^
src/z_zone.h:99:43: error: expected declaration specifiers or '...' before 'PU_STATIC'
   99 | #define calloc(n1,n2)      Z_Calloc(n1,n2,PU_STATIC,0)
      |                                           ^~~~~~~~~
src/z_zone.h:99:53: error: expected declaration specifiers or '...' before numeric constant
   99 | #define calloc(n1,n2)      Z_Calloc(n1,n2,PU_STATIC,0)
      |                                                     ^
make: *** [Makefile:776: libretro/libretro-common/vfs/vfs_implementation.o] Error 1
```