### PR TITLE
Fix the emscripten build: two copies of memmap in one link

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -48,8 +48,7 @@ SOURCES_C := $(LIBRETRO_DIR)/libretro.c \
 				 $(LIBRETRO_COMM_DIR)/formats/mod/rmodtracker.c \
 				 $(LIBRETRO_COMM_DIR)/formats/data_transfer.c \
 				 $(LIBRETRO_COMM_DIR)/formats/audio_transfer.c \
-				 $(LIBRETRO_COMM_DIR)/formats/image_transfer.c \
-				 $(LIBRETRO_COMM_DIR)/memmap/memmap.c
+				 $(LIBRETRO_COMM_DIR)/formats/image_transfer.c
 
 # The hybrid VFS only exists for dynamically loaded builds.  When the core is
 # statically linked, frontend and core share one libretro-common: griffin's
@@ -63,6 +62,21 @@ SOURCES_C := $(LIBRETRO_DIR)/libretro.c \
 ifneq ($(STATIC_LINKING), 1)
 SOURCES_C += $(LIBRETRO_COMM_DIR)/vfs/vfs_hybrid.c \
 				 $(LIBRETRO_COMM_DIR)/file/retro_dirent.c
+endif
+
+# memmap.c is here for data_transfer.c's page machinery, which a dynamically
+# loaded core has to bring along itself. A statically linked one does not:
+# RetroArch builds memmap.o unconditionally - it is in Makefile.common's plain
+# OBJ list and in griffin.c - and defines exactly the same eight symbols, so
+# compiling ours too only gives wasm-ld two of each and it refuses the link:
+#
+#   wasm-ld: error: duplicate symbol: memsync
+#   >>> defined in obj-emscripten/./libretro-common/memmap/memmap.o
+#   >>> defined in libretro_emscripten.a(memmap.o)
+#
+# Same reasoning as the hybrid VFS above, and the same fix.
+ifneq ($(STATIC_LINKING), 1)
+SOURCES_C += $(LIBRETRO_COMM_DIR)/memmap/memmap.c
 endif
 
 SOURCES_C += $(CORE_DIR)/am_map.c \


### PR DESCRIPTION
`libretro-build-emscripten` is the only red job in the pipeline, and it does not fail while compiling — it fails at the link:

```
wasm-ld: error: duplicate symbol: memsync
>>> defined in obj-emscripten/./libretro-common/memmap/memmap.o
>>> defined in libretro_emscripten.a(memmap.o)
```

and the same for `memprotect`, `mempagesize`, `memreserve`, `memcommit`, `memrearm`, `memdecommit` and `memrelease` — all eight of them.

**The chain.** `data_transfer.o` gets pulled out of our archive; it references `memcommit`, `memdecommit`, `mempagesize`, `memrearm`, `memrelease` and `memreserve`, so the linker then pulls our `memmap.o` out after it. RetroArch has already linked its own — `memmap.o` is in `Makefile.common`'s unconditional `OBJ` list and `griffin.c` includes it — so each of those symbols is now defined twice.

**Why excluding ours is safe.** `memmap.c` is in `Makefile.common` for `data_transfer.c`'s page machinery, which a dynamically loaded core does have to bring along itself. A statically linked one does not: RetroArch builds it on every platform, unconditionally, and both trees define exactly the same eight symbols — so our copy contributes nothing except the collision. That is the same reasoning as the hybrid VFS exclusion a few lines above in that file, and the same fix.

**Checked both ways, locally:**

- dynamic: `memmap.o` is still compiled and the resulting `.so` still carries `memsync` and `memreserve`
- static: the archive no longer contains `memmap.o`, while `data_transfer.o` is still in it and still references those six symbols — which is the point, they now resolve against the frontend's copy

What I could not check here is the emscripten link itself; that needs the buildbot. But the failure is a plain duplicate-definition one, and this removes one of the two definitions on exactly the builds where the other is guaranteed present.